### PR TITLE
Issue 21 - implemented pathway coherence metrics and umap layouts

### DIFF
--- a/src/napistu_torch/evaluation/constants.py
+++ b/src/napistu_torch/evaluation/constants.py
@@ -7,3 +7,8 @@ EVALUATION_TENSORS = SimpleNamespace(
 EVALUATION_TENSOR_DESCRIPTIONS = {
     EVALUATION_TENSORS.COMPREHENSIVE_PATHWAY_MEMBERSHIPS: "Comprehensive source membership from SBML_dfs",
 }
+
+PATHWAY_SIMILARITY_DEFS = SimpleNamespace(
+    OVERALL="overall",
+    OTHER="other",
+)

--- a/src/napistu_torch/evaluation/pathways.py
+++ b/src/napistu_torch/evaluation/pathways.py
@@ -1,4 +1,9 @@
+from typing import Optional
+
+import numpy as np
 import torch
+import torch.nn.functional as F
+from napistu.ingestion.constants import DEFAULT_PRIORITIZED_PATHWAYS
 from napistu.network.constants import (
     ADDING_ENTITY_DATA_DEFS,
     NAPISTU_GRAPH_VERTICES,
@@ -10,8 +15,57 @@ from napistu.sbml_dfs_core import SBML_dfs
 from napistu_torch.evaluation.constants import (
     EVALUATION_TENSOR_DESCRIPTIONS,
     EVALUATION_TENSORS,
+    PATHWAY_SIMILARITY_DEFS,
 )
+from napistu_torch.ml.torch_utils import memory_manager
 from napistu_torch.vertex_tensor import VertexTensor
+
+
+def calculate_pathway_similarities(
+    embedding_matrix: torch.Tensor,
+    pathway_assignments: torch.Tensor,
+    pathway_names: list[str],
+    filtering_mask: Optional[torch.Tensor] = None,
+    priority_pathways: list[str] = DEFAULT_PRIORITIZED_PATHWAYS,
+    device: torch.device = None,
+) -> dict[str, float]:
+    """
+    Calculate pathway similarity based on average within-category cosine similarity.
+
+    Parameters
+    ----------
+    embedding_matrix: torch.Tensor
+        (I, K) tensor of feature embeddings
+    pathway_assignments: torch.Tensor
+        (I, C) binary tensor of category memberships
+    pathway_names: list[str]
+        list of category/pathway names corresponding to per_category_sim
+    filtering_mask:
+        optional (I,) tensor of boolean mask to filter embeddings and assignments
+
+    Returns
+    -------
+    dict mapping pathway names to their similarities:
+    """
+
+    if filtering_mask is None:
+        filtering_mask = torch.ones_like(pathway_assignments, dtype=torch.bool)
+
+    per_cat_sim, overall_sim = _within_category_similarity(
+        embedding_matrix[filtering_mask],
+        pathway_assignments[filtering_mask],
+        device=device,
+    )
+
+    pathway_similarities = _rollup_pathway_similarities(
+        per_category_sim=per_cat_sim,
+        pathway_names=pathway_names,
+        priority_pathways=priority_pathways,
+    )
+
+    pathway_similarities[PATHWAY_SIMILARITY_DEFS.OVERALL] = overall_sim
+
+    return pathway_similarities
 
 
 def get_comprehensive_source_membership(
@@ -47,14 +101,15 @@ def get_comprehensive_source_membership(
     vertex_pathway_memberships = (
         working_napistu_graph.get_vertex_dataframe().select_dtypes(include=[int])
     )
+    binary_pathway_memberships = (vertex_pathway_memberships > 0).astype(int)
 
     ng_vertex_names = working_napistu_graph.get_vertex_series(
         NAPISTU_GRAPH_VERTICES.NAME
     )
-    feature_names = vertex_pathway_memberships.columns.tolist()
+    feature_names = binary_pathway_memberships.columns.tolist()
 
     return VertexTensor(
-        data=torch.Tensor(vertex_pathway_memberships.values),
+        data=torch.Tensor(binary_pathway_memberships.values),
         feature_names=feature_names,
         vertex_names=ng_vertex_names,
         name=EVALUATION_TENSORS.COMPREHENSIVE_PATHWAY_MEMBERSHIPS,
@@ -62,3 +117,108 @@ def get_comprehensive_source_membership(
             EVALUATION_TENSORS.COMPREHENSIVE_PATHWAY_MEMBERSHIPS
         ],
     )
+
+
+# private functions
+
+
+def _rollup_pathway_similarities(
+    per_category_sim: np.ndarray,
+    pathway_names: list[str],
+    priority_pathways: list[str] = DEFAULT_PRIORITIZED_PATHWAYS,
+) -> dict[str, float]:
+    """
+    Rollup per-category similarities into individual priority pathways and aggregated others.
+
+    Parameters
+    ----------
+    per_category_sim: numpy.ndarray
+        (C,) array of average cosine similarities per category
+    pathway_names: list
+        category/pathway names corresponding to per_category_sim
+    priority_pathways: list
+        priority pathway names (these pathways will be preserved as their own entries)
+
+    Returns
+    -------
+    dict mapping pathway names to their similarities:
+        - Each priority pathway gets its own entry
+        - All other pathways are averaged into a single 'other' entry
+    """
+    priority_set = set(priority_pathways)
+
+    result = {}
+    other_sims = []
+
+    for name, sim in zip(pathway_names, per_category_sim):
+        if name in priority_set:
+            result[name] = sim
+        else:
+            other_sims.append(sim)
+
+    # Add aggregated 'other' category
+    if other_sims:
+        result[PATHWAY_SIMILARITY_DEFS.OTHER] = np.mean(other_sims)
+
+    return result
+
+
+def _within_category_similarity(
+    embeddings: torch.Tensor,
+    categories: torch.Tensor,
+    device: torch.device = None,
+) -> tuple[np.ndarray, float]:
+    """
+    Calculate average within-category cosine similarity (excluding self-pairs).
+
+    Parameters
+    ----------
+    embeddings: torch.Tensor
+        (I, K) tensor of feature embeddings
+    categories: torch.Tensor
+        (I, C) binary tensor of category memberships
+    device: torch.device
+        device to use (if None, uses embeddings.device)
+
+    Returns
+    -------
+    tuple[np.ndarray, float]
+        per_category_sim: (C,) numpy array of average cosine similarities per category
+        overall_sim: float
+            average across all categories
+    """
+    if device is None:
+        device = embeddings.device
+
+    with memory_manager(device):
+        # Ensure inputs are on the correct device
+        embeddings = embeddings.to(device)
+        categories = categories.to(device)
+
+        # Normalize embeddings for cosine similarity
+        embeddings_norm = F.normalize(embeddings, p=2, dim=1)
+
+        # Compute all pairwise cosine similarities
+        similarity_matrix = embeddings_norm @ embeddings_norm.T
+
+        # Compute category similarity sums
+        category_similarity_sums = categories.T @ similarity_matrix @ categories
+        within_sums = torch.diag(category_similarity_sums)
+
+        # Subtract diagonal entries (self-similarities)
+        members_per_category = categories.sum(dim=0)
+        within_sums = within_sums - members_per_category
+
+        # Divide by N*(N-1) pairs (excluding self-pairs)
+        num_pairs = members_per_category * (members_per_category - 1)
+
+        per_category_sim = within_sums / num_pairs.clamp(min=1)
+        overall_sim = within_sums.sum() / num_pairs.sum().clamp(min=1)
+
+        # Convert to numpy
+        per_category_sim = per_category_sim.cpu().numpy()
+        overall_sim = (
+            overall_sim.item()
+        )  # .item() converts scalar tensor to Python float
+
+        return per_category_sim, overall_sim

--- a/src/napistu_torch/vertex_tensor.py
+++ b/src/napistu_torch/vertex_tensor.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import List, Optional, Union
 
@@ -6,6 +7,9 @@ import torch
 
 from napistu_torch.constants import VERTEX_TENSOR
 from napistu_torch.ml.constants import DEVICE
+from napistu_torch.napistu_data import NapistuData
+
+logger = logging.getLogger(__name__)
 
 
 class VertexTensor:
@@ -34,6 +38,8 @@ class VertexTensor:
         Save the VertexTensor to disk
     load(filepath, map_location="cpu")
         Load a VertexTensor from disk
+    align_to_napistu_data(napistu_data, inplace=True)
+        Align this VertexTensor to match the vertex ordering in NapistuData
     """
 
     def __init__(
@@ -50,6 +56,108 @@ class VertexTensor:
         self.name = name
         self.description = description
 
+    def align_to_napistu_data(
+        self, napistu_data: NapistuData, inplace: bool = True
+    ) -> "VertexTensor":
+        """
+        Align this VertexTensor to match the vertex ordering in NapistuData.
+
+        Validates that vertex names match and reorders the tensor data if
+        necessary to align with the NapistuData vertex ordering.
+
+        Parameters
+        ----------
+        napistu_data : NapistuData
+            The NapistuData object to align to
+        inplace : bool, default=True
+            If True, modify this VertexTensor in place. If False, return
+            a new VertexTensor with the alignment applied.
+
+        Returns
+        -------
+        VertexTensor
+            The aligned VertexTensor (self if inplace=True, new instance otherwise)
+
+        Raises
+        ------
+        ValueError
+            If the number of vertices don't match or if vertex names don't match
+        """
+        # Validate number of vertices
+        if self.data.shape[0] != napistu_data.x.shape[0]:
+            raise ValueError(
+                f"Vertex tensor and NapistuData have different numbers of rows: "
+                f"{self.data.shape[0]} != {napistu_data.x.shape[0]}"
+            )
+
+        nd_vertex_names = napistu_data.get_vertex_names()
+
+        # Handle case where NapistuData has no vertex names
+        if nd_vertex_names is None:
+            logger.warning(
+                "No vertex names found in NapistuData, so `vertex_tensor`'s "
+                "alignment to NapistuData will be assumed but not confirmed"
+            )
+            return self if inplace else self.copy()
+
+        # Case 1: Vertex names are identical and in the same order
+        if (nd_vertex_names.values == self.vertex_names.values).all():
+            logger.debug("Vertex names already aligned with NapistuData")
+            return self if inplace else self.copy()
+
+        # Case 2: Same vertex names but different order
+        if set(nd_vertex_names.values) == set(self.vertex_names.values):
+            # Create a mapping from vertex names to indices in this VertexTensor
+            vt_name_to_idx = {
+                name: idx for idx, name in enumerate(self.vertex_names.values)
+            }
+
+            # Create reordering indices based on nd_vertex_names order
+            reorder_indices = [vt_name_to_idx[name] for name in nd_vertex_names.values]
+
+            # Reorder data
+            reordered_data = self.data[reorder_indices]
+
+            logger.info(
+                f"Reordered VertexTensor '{self.name}' to match NapistuData vertex ordering"
+            )
+
+            if inplace:
+                self.data = reordered_data
+                self.vertex_names = nd_vertex_names.copy()
+                return self
+            else:
+                return VertexTensor(
+                    data=reordered_data,
+                    feature_names=self.feature_names.copy(),
+                    vertex_names=nd_vertex_names.copy(),
+                    name=self.name,
+                    description=self.description,
+                )
+
+        # Case 3: Vertex names don't match
+        raise ValueError(
+            f"Vertex names in VertexTensor '{self.name}' and NapistuData do not match"
+        )
+
+    def copy(self) -> "VertexTensor":
+        """Create a deep copy of this VertexTensor."""
+        return VertexTensor(
+            data=self.data.clone(),
+            feature_names=self.feature_names.copy(),
+            vertex_names=self.vertex_names.copy(),
+            name=self.name,
+            description=self.description,
+        )
+
+    @classmethod
+    def load(
+        cls, filepath: Union[str, Path], map_location: str = DEVICE.CPU
+    ) -> "VertexTensor":
+        """Load from disk."""
+        saved = torch.load(filepath, weights_only=False, map_location=map_location)
+        return cls(**saved)
+
     def save(self, filepath: Union[str, Path]) -> None:
         """Save to disk."""
         torch.save(
@@ -62,11 +170,3 @@ class VertexTensor:
             },
             filepath,
         )
-
-    @classmethod
-    def load(
-        cls, filepath: Union[str, Path], map_location: str = DEVICE.CPU
-    ) -> "VertexTensor":
-        """Load from disk."""
-        saved = torch.load(filepath, weights_only=False, map_location=map_location)
-        return cls(**saved)

--- a/src/napistu_torch/visualization/__init__.py
+++ b/src/napistu_torch/visualization/__init__.py
@@ -1,0 +1,4 @@
+"""Visualization utilities for napistu-torch.
+
+This subpackage provides visualization tools and utilities for visualizing embedding, model performance, and other metrics.
+"""

--- a/src/napistu_torch/visualization/embeddings.py
+++ b/src/napistu_torch/visualization/embeddings.py
@@ -1,0 +1,137 @@
+import torch
+from sklearn.manifold import TSNE
+
+try:
+    import umap
+
+    UMAP_AVAILABLE = True
+except ImportError:
+    UMAP_AVAILABLE = False
+
+
+@torch.no_grad()
+def layout_tsne(
+    model, filtering_mask=None, n_components=2, perplexity=30, random_state=42
+):
+    """
+    Layout embeddings in 2D using t-SNE with sensible defaults.
+
+    For large datasets (>10K), t-SNE becomes impractically slow.
+    Use filtering_mask to subset the data or consider using UMAP instead.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        Model with embedding layer
+    filtering_mask : torch.Tensor or None, optional
+        Boolean mask of shape (n_features,) to select subset of embeddings.
+        If None, uses all embeddings, by default None
+    n_components : int, optional
+        Number of dimensions, by default 2
+    perplexity : int, optional
+        Balance between local and global structure, by default 30.
+        Reasonable range: 5-50 depending on dataset size
+    random_state : int, optional
+        Random seed for reproducibility, by default 42
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape (n_selected, n_components) containing 2D embeddings
+    """
+    model.eval()
+
+    if hasattr(model, "embedding"):
+        z = model.embedding.weight.data
+    else:
+        z = model()
+
+    # Apply filtering mask
+    if filtering_mask is None:
+        filtering_mask = torch.ones(z.shape[0], dtype=torch.bool, device=z.device)
+
+    z = z[filtering_mask].cpu().numpy()
+
+    reducer = TSNE(
+        n_components=n_components,
+        perplexity=perplexity,
+        learning_rate="auto",
+        n_iter=1000,
+        random_state=random_state,
+        init="pca",
+        metric="cosine",
+    )
+
+    z_2d = reducer.fit_transform(z)
+    return z_2d
+
+
+@torch.no_grad()
+def layout_umap(
+    model, filtering_mask=None, n_components=2, n_neighbors=15, random_state=42
+):
+    """
+    Layout embeddings in 2D using UMAP with sensible defaults.
+
+    UMAP is generally preferred for embeddings: faster, more stable,
+    and better at preserving both local and global structure. UMAP
+    scales well to large datasets (100K+ samples).
+
+    Note: Requires umap-learn package. Install with:
+        pip install napistu-torch[viz]
+    or
+        pip install umap-learn
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        Model with embedding layer
+    filtering_mask : torch.Tensor or None, optional
+        Boolean mask of shape (n_features,) to select subset of embeddings.
+        If None, uses all embeddings, by default None
+    n_components : int, optional
+        Number of dimensions, by default 2
+    n_neighbors : int, optional
+        Size of local neighborhood, by default 15.
+        Reasonable range: 5-50 depending on desired granularity
+    random_state : int, optional
+        Random seed for reproducibility, by default 42
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape (n_selected, n_components) containing 2D embeddings
+
+    Raises
+    ------
+    ImportError
+        If umap-learn is not installed
+    """
+    if not UMAP_AVAILABLE:
+        raise ImportError(
+            "UMAP is not installed. Install it with:\n" "  pip install umap-learn"
+        )
+
+    model.eval()
+
+    if hasattr(model, "embedding"):
+        z = model.embedding.weight.data
+    else:
+        z = model()
+
+    # Apply filtering mask
+    if filtering_mask is None:
+        filtering_mask = torch.ones(z.shape[0], dtype=torch.bool, device=z.device)
+
+    z = z[filtering_mask].cpu().numpy()
+
+    reducer = umap.UMAP(
+        n_components=n_components,
+        n_neighbors=n_neighbors,
+        min_dist=0.1,
+        metric="cosine",
+        random_state=random_state,
+    )
+
+    z_2d = reducer.fit_transform(z)
+    return z_2d

--- a/src/tests/test_vertex_tensor.py
+++ b/src/tests/test_vertex_tensor.py
@@ -1,0 +1,109 @@
+"""
+Tests for VertexTensor class functionality.
+"""
+
+import pandas as pd
+import pytest
+import torch
+
+from napistu_torch.vertex_tensor import VertexTensor
+
+
+def test_align_to_napistu_data(napistu_data, comprehensive_source_membership):
+    """Test align_to_napistu_data method with various alignment scenarios."""
+
+    # Test Case 1: Already aligned (same order)
+    # First, ensure they're aligned by calling align_to_napistu_data
+    aligned_tensor = comprehensive_source_membership.align_to_napistu_data(
+        napistu_data, inplace=False
+    )
+
+    # Test Case 2: Different order but same vertices
+    # Create a reordered version of the comprehensive_source_membership
+    vertex_names = comprehensive_source_membership.vertex_names
+    data = comprehensive_source_membership.data
+
+    # Reorder the data (reverse order)
+    reorder_indices = list(range(len(vertex_names)))[::-1]
+    reordered_data = data[reorder_indices]
+    reordered_vertex_names = vertex_names.iloc[reorder_indices]
+
+    reordered_tensor = VertexTensor(
+        data=reordered_data,
+        feature_names=comprehensive_source_membership.feature_names.copy(),
+        vertex_names=reordered_vertex_names,
+        name="reordered_tensor",
+    )
+
+    # Test alignment with reordered data
+    aligned_reordered = reordered_tensor.align_to_napistu_data(
+        napistu_data, inplace=False
+    )
+
+    # Verify the aligned tensor matches the original alignment
+    assert torch.allclose(
+        aligned_reordered.data, aligned_tensor.data
+    ), "Reordered alignment should match original"
+    assert (
+        aligned_reordered.vertex_names.values.tolist()
+        == aligned_tensor.vertex_names.values.tolist()
+    ), "Vertex names should match"
+
+    # Test Case 3: Subset of vertices
+    # Create a subset tensor with only the first half of vertices
+    subset_size = len(vertex_names) // 2
+    subset_data = data[:subset_size]
+    subset_vertex_names = vertex_names.iloc[:subset_size]
+
+    subset_tensor = VertexTensor(
+        data=subset_data,
+        feature_names=comprehensive_source_membership.feature_names.copy(),
+        vertex_names=subset_vertex_names,
+        name="subset_tensor",
+    )
+
+    # Test that subset fails alignment due to different number of vertices
+    with pytest.raises(ValueError, match="different numbers of rows"):
+        subset_tensor.align_to_napistu_data(napistu_data)
+
+    # Test Case 4: Different vertex names (should fail)
+    # Create a tensor with completely different vertex names
+    fake_vertex_names = pd.Index([f"fake_vertex_{i}" for i in range(len(vertex_names))])
+    fake_tensor = VertexTensor(
+        data=data,
+        feature_names=comprehensive_source_membership.feature_names.copy(),
+        vertex_names=fake_vertex_names,
+        name="fake_tensor",
+    )
+
+    # Test that different vertex names fail alignment
+    with pytest.raises(ValueError, match="Vertex names.*do not match"):
+        fake_tensor.align_to_napistu_data(napistu_data)
+
+    # Test Case 5: Test inplace=False vs inplace=True
+    original_data = reordered_tensor.data.clone()
+    original_vertex_names = reordered_tensor.vertex_names.copy()
+
+    # Test inplace=True
+    result_inplace = reordered_tensor.align_to_napistu_data(napistu_data, inplace=True)
+    assert result_inplace is reordered_tensor, "Should return self when inplace=True"
+    assert not torch.allclose(
+        reordered_tensor.data, original_data
+    ), "Data should be modified in place"
+    assert not reordered_tensor.vertex_names.equals(
+        original_vertex_names
+    ), "Vertex names should be modified in place"
+
+    # Test inplace=False (restore original first)
+    reordered_tensor.data = original_data
+    reordered_tensor.vertex_names = original_vertex_names
+    result_copy = reordered_tensor.align_to_napistu_data(napistu_data, inplace=False)
+    assert (
+        result_copy is not reordered_tensor
+    ), "Should return new instance when inplace=False"
+    assert torch.allclose(
+        reordered_tensor.data, original_data
+    ), "Original data should be unchanged"
+    assert reordered_tensor.vertex_names.equals(
+        original_vertex_names
+    ), "Original vertex names should be unchanged"


### PR DESCRIPTION
- added `calculate_pathway_similarities` for calculating cosine similarities within individual pathways using the `VertexTensor` from `get_comprehensive_source_membership`.
- methods for pulling tensors by name and regex in `NapistuData`
- added `align_to_napistu_data` method for `VertexTensor` to verify (and try to fix) its alignment to `NapistuData` using each objects vertex names.
- added UMAP and t-snee  manifold layouts.
Closes #21 