### PR TITLE
Issue 53 - Removed edge_encoder attribute from MessagePassingEncoder

### DIFF
--- a/src/napistu_torch/configs.py
+++ b/src/napistu_torch/configs.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from napistu_torch.constants import (
     DATA_CONFIG,
@@ -97,8 +97,7 @@ class ModelConfig(BaseModel):
             raise ValueError(f"hidden_channels should be power of 2, got {v}")
         return v
 
-    class Config:
-        extra = "forbid"  # Catch typos
+    model_config = ConfigDict(extra="forbid")  # Catch typos
 
 
 class DataConfig(BaseModel):
@@ -123,8 +122,7 @@ class DataConfig(BaseModel):
         description="List of additional artifact names that must exist in the store.",
     )
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class TaskConfig(BaseModel):
@@ -150,8 +148,7 @@ class TaskConfig(BaseModel):
             raise ValueError(f"Invalid task: {v}. Valid tasks are: {VALID_TASKS}")
         return v
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class TrainingConfig(BaseModel):
@@ -200,8 +197,7 @@ class TrainingConfig(BaseModel):
             )
         return v
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class WandBConfig(BaseModel):
@@ -245,8 +241,7 @@ class WandBConfig(BaseModel):
         )
         return enhanced_tags
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class ExperimentConfig(BaseModel):
@@ -269,8 +264,7 @@ class ExperimentConfig(BaseModel):
     limit_train_batches: float = 1.0
     limit_val_batches: float = 1.0
 
-    class Config:
-        extra = "forbid"  # Catch config typos!
+    model_config = ConfigDict(extra="forbid")  # Catch config typos!
 
     # Convenience methods
     def to_dict(self):

--- a/src/napistu_torch/models/constants.py
+++ b/src/napistu_torch/models/constants.py
@@ -33,6 +33,9 @@ VALID_ENCODER_NAMED_ARGS = list(ENCODER_SPECIFIC_ARGS.__dict__.values())
 ENCODER_DEFS = SimpleNamespace(
     GRAPH_CONV_DEFAULT_AGGREGATOR="mean",
     SAGE_DEFAULT_AGGREGATOR="mean",
+    # derived encoder attributes
+    EDGE_WEIGHTING_TYPE="edge_weighting_type",
+    EDGE_WEIGHTING_VALUE="edge_weighting_value",
 )
 
 # select the relevant arguments and convert from the {encoder}_{arg} convention back to just arg
@@ -71,4 +74,10 @@ EDGE_ENCODER_ARGS = SimpleNamespace(
     EDGE_IN_CHANNELS="edge_in_channels",
     EDGE_ENCODER_DIM="edge_encoder_dim",
     EDGE_ENCODER_DROPOUT="edge_encoder_dropout",
+)
+
+EDGE_WEIGHTING_TYPE = SimpleNamespace(
+    NONE="none",
+    STATIC_WEIGHTS="static_weights",
+    LEARNED_ENCODER="learned_encoder",
 )

--- a/src/tests/test_lightning_tasks.py
+++ b/src/tests/test_lightning_tasks.py
@@ -170,16 +170,23 @@ def test_edge_prediction_with_edge_encoder(edge_masked_napistu_data, experiment_
     assert "auc" in metrics
     assert "ap" in metrics
 
-    # Verify edge encoder was created and integrated
-    assert task.edge_encoder is not None
-    assert task.edge_encoder.edge_dim == 10
-    assert task.edge_encoder.hidden_dim == 16
+    # Verify edge encoder was created and integrated in the encoder
+    from napistu_torch.models.constants import EDGE_WEIGHTING_TYPE, ENCODER_DEFS
+
+    assert hasattr(encoder, ENCODER_DEFS.EDGE_WEIGHTING_TYPE)
+    assert (
+        getattr(encoder, ENCODER_DEFS.EDGE_WEIGHTING_TYPE)
+        == EDGE_WEIGHTING_TYPE.LEARNED_ENCODER
+    )
+    assert hasattr(encoder, ENCODER_DEFS.EDGE_WEIGHTING_VALUE)
+    edge_encoder = getattr(encoder, ENCODER_DEFS.EDGE_WEIGHTING_VALUE)
+    assert edge_encoder is not None
+    assert edge_encoder.edge_dim == 10
+    assert edge_encoder.hidden_dim == 16
 
     # Verify edge encoder is properly integrated into the MessagePassingEncoder
-    assert hasattr(encoder, "edge_encoder")
-    assert encoder.edge_encoder is not None
-    assert encoder.weight_edges_by is not None
-    assert encoder.weight_edges_by is encoder.edge_encoder
+    # The edge encoder is stored in edge_weighting_value when type is LEARNED_ENCODER
+    assert edge_encoder is getattr(encoder, ENCODER_DEFS.EDGE_WEIGHTING_VALUE)
 
     # Verify that the encoder uses the edge encoder during forward pass
     # by checking that it requires edge_data when edge encoder is present


### PR DESCRIPTION
- Cleaned up weight_edges_by approach in MessagePassingEncoder to track the weighting strategy by edge_weighting_type and edge_weighting_value to avoid duplicate registration of the edge encoder. Closes #53 
- Minor Pydantic fixes to resolve deprecation warning.