### PR TITLE
Issue 91 - added relation-type-based stratification when calculating loss and AUC

### DIFF
--- a/src/napistu_torch/constants.py
+++ b/src/napistu_torch/constants.py
@@ -124,13 +124,6 @@ NAPISTU_DATA_STORE_STRUCTURE = SimpleNamespace(
 
 # Configs
 
-METRICS = SimpleNamespace(
-    AUC="auc",
-    AP="ap",
-)
-
-VALID_METRICS = list(METRICS.__dict__.values())
-
 OPTIMIZERS = SimpleNamespace(
     ADAM="adam",
     ADAMW="adamw",

--- a/src/napistu_torch/lightning/workflows.py
+++ b/src/napistu_torch/lightning/workflows.py
@@ -734,7 +734,16 @@ def _create_model(
         num_relations = None
 
     head = Decoder.from_config(config.model, num_relations=num_relations)
-    task = EdgePredictionTask(encoder, head, edge_strata=edge_strata)
+    task = EdgePredictionTask(
+        encoder,
+        head,
+        neg_sampling_ratio=config.task.edge_prediction_neg_sampling_ratio,
+        edge_strata=edge_strata,
+        neg_sampling_strategy=config.task.edge_prediction_neg_sampling_strategy,
+        metrics=config.task.metrics,
+        weight_loss_by_relation_frequency=config.task.weight_loss_by_relation_frequency,
+        loss_weight_alpha=config.task.loss_weight_alpha,
+    )
 
     # 4. create lightning module
     if verbose:

--- a/src/napistu_torch/ml/constants.py
+++ b/src/napistu_torch/ml/constants.py
@@ -27,6 +27,18 @@ VALID_DEVICES = list(DEVICE.__dict__.values())
 
 # metrics
 
+METRICS = SimpleNamespace(
+    AUC="auc",
+    AP="ap",
+)
+
+VALID_METRICS = list(METRICS.__dict__.values())
+
+RELATION_WEIGHTED_AUC_DEFS = SimpleNamespace(
+    RELATION_WEIGHTED_AUC="relation_weighted_auc",
+    RELATION_AUC_TEMPLATE="auc_{relation_name}",
+)
+
 METRIC_SUMMARIES = SimpleNamespace(
     VAL_AUC="val_auc",
     TEST_AUC="test_auc",

--- a/src/napistu_torch/ml/metrics.py
+++ b/src/napistu_torch/ml/metrics.py
@@ -1,0 +1,199 @@
+"""Custom metrics for model evaluation."""
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from sklearn.metrics import roc_auc_score
+
+from napistu_torch.labels.apply import decode_labels
+from napistu_torch.labels.labeling_manager import LabelingManager
+from napistu_torch.ml.constants import METRICS, RELATION_WEIGHTED_AUC_DEFS
+
+logger = logging.getLogger(__name__)
+
+
+class RelationWeightedAUC:
+    """
+    Compute per-relation AUC and weighted average AUC.
+
+    Computes:
+    1. Overall AUC (all samples pooled, unweighted)
+    2. Per-relation AUCs (one for each relation type)
+    3. Relation-weighted AUC (weighted by loss_weight × validation_count)
+
+    Parameters
+    ----------
+    loss_weights : torch.Tensor
+        Pre-computed loss weights from training [num_relations]
+    loss_weight_alpha : float
+        Alpha parameter used for loss weighting (for logging/reference)
+    relation_manager : LabelingManager, optional
+        Manager for decoding relation type indices to human-readable names
+
+    Public Methods
+    --------------
+    compute(y_true, y_pred, relation_type)
+        Compute overall, per-relation, and weighted AUCs.
+
+    Examples
+    --------
+    >>> # During validation
+    >>> rw_auc = RelationWeightedAUC(
+    ...     loss_weights=task._relation_weights,
+    ...     loss_weight_alpha=task.loss_weight_alpha,
+    ...     relation_manager=data.relation_manager
+    ... )
+    >>> metrics = rw_auc.compute(y_true, y_pred, relation_type)
+    >>> print(metrics)
+    {
+        'auc': 0.85,
+        'auc_relation_weighted': 0.82,
+        'auc_catalysis': 0.78,
+        'auc_interaction': 0.88,
+        'auc_inhibition': 0.81
+    }
+    """
+
+    def __init__(
+        self,
+        loss_weights: torch.Tensor,
+        loss_weight_alpha: float,
+        relation_manager: Optional[LabelingManager] = None,
+    ):
+        self.loss_weights = loss_weights
+        self.loss_weight_alpha = loss_weight_alpha
+        self.relation_manager = relation_manager
+
+    def compute(
+        self,
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+        relation_type: torch.Tensor,
+    ) -> Dict[str, float]:
+        """
+        Compute overall, per-relation, and weighted AUCs.
+
+        Parameters
+        ----------
+        y_true : np.ndarray
+            True binary labels [num_samples]
+        y_pred : np.ndarray
+            Predicted probabilities [num_samples]
+        relation_type : torch.Tensor
+            Relation type index for each sample [num_samples]
+
+        Returns
+        -------
+        Dict[str, float]
+            Dictionary containing:
+            - 'auc': Overall AUC (all samples pooled)
+            - 'auc_relation_weighted': Weighted average of per-relation AUCs
+            - 'auc_{relation_name}': Per-relation AUC for each relation type
+        """
+
+        results = {}
+
+        # Overall AUC (unweighted, all samples pooled)
+        results[METRICS.AUC] = roc_auc_score(y_true, y_pred)
+
+        # Per-relation AUCs and counts
+        relation_type_np = relation_type.cpu().numpy()
+        unique_relations = np.unique(relation_type_np)
+
+        per_relation_aucs, per_relation_counts, per_relation_results = (
+            _compute_per_relation_aucs(
+                y_true, y_pred, relation_type, unique_relations, self.relation_manager
+            )
+        )
+
+        # Add per-relation AUCs to results
+        results.update(per_relation_results)
+
+        # Weighted AUC: adjusted_weights = loss_weights × val_counts
+        per_relation_aucs = np.array(per_relation_aucs)
+        per_relation_counts = np.array(per_relation_counts)
+
+        # Get corresponding loss weights for these relations
+        loss_weights_np = self.loss_weights[unique_relations].cpu().numpy()
+
+        # Compute adjusted weights: (1/freq^alpha) × validation_count
+        adjusted_weights = loss_weights_np * per_relation_counts
+
+        # Weighted average
+        results[RELATION_WEIGHTED_AUC_DEFS.RELATION_WEIGHTED_AUC] = (
+            adjusted_weights * per_relation_aucs
+        ).sum() / adjusted_weights.sum()
+
+        logger.debug(
+            f"Relation-weighted AUC computed: "
+            f"overall={results[METRICS.AUC]:.3f}, "
+            f"weighted={results[RELATION_WEIGHTED_AUC_DEFS.RELATION_WEIGHTED_AUC]:.3f}"
+        )
+
+        return results
+
+
+def _compute_per_relation_aucs(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    relation_type: torch.Tensor,
+    unique_relations: np.ndarray,
+    relation_manager: Optional[LabelingManager] = None,
+) -> Tuple[List[float], List[int], Dict[str, float]]:
+    """
+    Compute per-relation AUCs for each relation type.
+
+    Parameters
+    ----------
+    y_true : np.ndarray
+        True binary labels [num_samples]
+    y_pred : np.ndarray
+        Predicted probabilities [num_samples]
+    relation_type : torch.Tensor
+        Relation type index for each sample [num_samples]
+    unique_relations : np.ndarray
+        Unique relation type indices (in sorted order)
+    relation_manager : LabelingManager, optional
+        Manager for decoding relation type indices to human-readable names
+
+    Returns
+    -------
+    per_relation_aucs : List[float]
+        AUC for each relation type (in order of unique_relations)
+    per_relation_counts : List[int]
+        Number of samples for each relation type (in order of unique_relations)
+    per_relation_results : Dict[str, float]
+        Dictionary mapping 'auc_{relation_name}' to AUC value for each relation
+    """
+    relation_type_np = relation_type.cpu().numpy()
+
+    per_relation_aucs = []
+    per_relation_counts = []
+    per_relation_results = {}
+
+    for rel_idx in unique_relations:
+        mask = relation_type_np == rel_idx
+        rel_y_true = y_true[mask]
+        rel_y_pred = y_pred[mask]
+
+        # Compute per-relation AUC
+        rel_auc = roc_auc_score(rel_y_true, rel_y_pred)
+        per_relation_aucs.append(rel_auc)
+        per_relation_counts.append(mask.sum())
+
+        # Get human-readable relation name
+        if relation_manager is not None:
+            rel_name = decode_labels(torch.tensor([rel_idx]), relation_manager)[0]
+        else:
+            rel_name = str(rel_idx)
+
+        # Store per-relation AUC
+        per_relation_results[
+            RELATION_WEIGHTED_AUC_DEFS.RELATION_AUC_TEMPLATE.format(
+                relation_name=rel_name
+            )
+        ] = rel_auc
+
+    return per_relation_aucs, per_relation_counts, per_relation_results

--- a/src/napistu_torch/napistu_data.py
+++ b/src/napistu_torch/napistu_data.py
@@ -869,7 +869,11 @@ class NapistuData(Data):
         **What's Always Removed:**
         - ng_vertex_names, ng_edge_names (pandas objects)
         - vertex_feature_names, edge_feature_names (metadata)
-        - name, splitting_strategy, labeling_manager, relation_manager (metadata)
+        - name, splitting_strategy (metadata)
+
+        **Conditionally Kept:**
+        - labeling_manager: Kept if keep_labels=True (needed for label metadata)
+        - relation_manager: Kept if keep_relation_type=True (needed for relation metadata)
 
         Parameters
         ----------
@@ -939,6 +943,11 @@ class NapistuData(Data):
         # Add labels if requested
         if keep_labels and hasattr(self, PYG.Y) and self.y is not None:
             new_attrs[PYG.Y] = self.y
+            # Also keep labeling_manager if labels are kept (needed for label metadata)
+            if hasattr(self, NAPISTU_DATA.LABELING_MANAGER):
+                labeling_manager = getattr(self, NAPISTU_DATA.LABELING_MANAGER)
+                if labeling_manager is not None:
+                    new_attrs[NAPISTU_DATA.LABELING_MANAGER] = labeling_manager
 
         # Add masks if requested
         if keep_masks:
@@ -957,6 +966,11 @@ class NapistuData(Data):
             new_attrs[NAPISTU_DATA.RELATION_TYPE] = getattr(
                 self, NAPISTU_DATA.RELATION_TYPE
             )
+            # Also keep relation_manager if relations are kept (needed for relation metadata)
+            if hasattr(self, NAPISTU_DATA.RELATION_MANAGER):
+                relation_manager = getattr(self, NAPISTU_DATA.RELATION_MANAGER)
+                if relation_manager is not None:
+                    new_attrs[NAPISTU_DATA.RELATION_MANAGER] = relation_manager
 
         if inplace:
             # Modify the object in place by clearing all attributes and setting new ones

--- a/src/tests/test_configs.py
+++ b/src/tests/test_configs.py
@@ -23,7 +23,6 @@ from napistu_torch.constants import (
     ANONYMIZATION_PLACEHOLDER_DEFAULT,
     DATA_CONFIG,
     EXPERIMENT_CONFIG,
-    METRICS,
     NAPISTU_DATA_TRIM_ARGS,
     OPTIMIZERS,
     PRETRAINED_COMPONENT_SOURCES,
@@ -43,6 +42,7 @@ from napistu_torch.load.constants import (
     STRATIFY_BY,
     STRATIFY_BY_ARTIFACT_NAMES,
 )
+from napistu_torch.ml.constants import METRICS
 from napistu_torch.models.constants import (
     ENCODER_SPECIFIC_ARGS,
     ENCODERS,

--- a/src/tests/test_ml_metrics.py
+++ b/src/tests/test_ml_metrics.py
@@ -1,0 +1,207 @@
+"""Tests for custom metrics."""
+
+import numpy as np
+import torch
+
+from napistu_torch.labels.labeling_manager import LabelingManager
+from napistu_torch.load.constants import STRATIFICATION_DEFS
+from napistu_torch.ml.constants import METRICS, RELATION_WEIGHTED_AUC_DEFS
+from napistu_torch.ml.metrics import RelationWeightedAUC
+
+
+def test_relation_weighted_auc():
+    """Test RelationWeightedAUC with 3 relations, 50 positive and 50 negative examples each."""
+    # Set random seed for reproducibility
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    # Create 3 relations with 50 positive and 50 negative examples each
+    num_relations = 3
+    num_samples_per_relation = 100  # 50 positive + 50 negative
+    total_samples = num_relations * num_samples_per_relation
+
+    # Create relation types: [0, 0, ..., 0, 1, 1, ..., 1, 2, 2, ..., 2]
+    relation_type = torch.repeat_interleave(
+        torch.arange(num_relations), num_samples_per_relation
+    )
+
+    # Create y_true: first 50 of each relation are positive (1), last 50 are negative (0)
+    y_true = np.zeros(total_samples, dtype=np.float32)
+    for rel_idx in range(num_relations):
+        start_idx = rel_idx * num_samples_per_relation
+        y_true[start_idx : start_idx + 50] = 1.0
+
+    # Create y_pred with different AUCs for each relation to test weighting
+    # Relation 0: AUC ~0.9 (good separation)
+    # Relation 1: AUC ~0.7 (moderate separation)
+    # Relation 2: AUC ~0.5 (poor separation, random)
+    y_pred = np.zeros(total_samples, dtype=np.float32)
+
+    for rel_idx in range(num_relations):
+        start_idx = rel_idx * num_samples_per_relation
+
+        if rel_idx == 0:
+            # Relation 0: Good separation
+            y_pred[start_idx : start_idx + 50] = np.random.beta(
+                8, 2, 50
+            )  # High scores for positives
+            y_pred[start_idx + 50 : start_idx + 100] = np.random.beta(
+                2, 8, 50
+            )  # Low scores for negatives
+        elif rel_idx == 1:
+            # Relation 1: Moderate separation
+            y_pred[start_idx : start_idx + 50] = np.random.beta(
+                5, 5, 50
+            )  # Medium-high scores for positives
+            y_pred[start_idx + 50 : start_idx + 100] = np.random.beta(
+                3, 7, 50
+            )  # Medium-low scores for negatives
+        else:
+            # Relation 2: Poor separation (random)
+            y_pred[start_idx : start_idx + 50] = np.random.beta(
+                3, 3, 50
+            )  # Random scores for positives
+            y_pred[start_idx + 50 : start_idx + 100] = np.random.beta(
+                3, 3, 50
+            )  # Random scores for negatives
+
+    # Create loss weights: [1.0, 2.0, 4.0] (relation 2 gets highest weight)
+    # These simulate weights from get_relation_weights with different frequencies
+    loss_weights = torch.tensor([1.0, 2.0, 4.0], dtype=torch.float32)
+    loss_weight_alpha = 0.5
+
+    # Create RelationWeightedAUC instance
+    rw_auc = RelationWeightedAUC(
+        loss_weights=loss_weights,
+        loss_weight_alpha=loss_weight_alpha,
+        relation_manager=None,  # No relation manager for this test
+    )
+
+    # Compute metrics
+    results = rw_auc.compute(y_true, y_pred, relation_type)
+    relation_names = {
+        i: RELATION_WEIGHTED_AUC_DEFS.RELATION_AUC_TEMPLATE.format(relation_name=i)
+        for i in range(num_relations)
+    }
+
+    # Verify results structure
+    assert METRICS.AUC in results
+    assert RELATION_WEIGHTED_AUC_DEFS.RELATION_WEIGHTED_AUC in results
+    for name in relation_names.values():
+        assert name in results
+
+    # Verify overall AUC is computed
+    assert isinstance(results[METRICS.AUC], float)
+    assert 0.0 <= results[METRICS.AUC] <= 1.0
+
+    # Verify per-relation AUCs
+    for relation_name in relation_names.values():
+        assert isinstance(results[relation_name], float)
+        assert 0.0 <= results[relation_name] <= 1.0
+
+    # Verify relation 0 has highest AUC (good separation)
+    assert results[relation_names[0]] > results[relation_names[1]]
+    assert results[relation_names[0]] > results[relation_names[2]]
+
+    # Verify relation 1 has higher AUC than relation 2 (moderate vs poor)
+    assert results[relation_names[1]] > results[relation_names[2]]
+
+    # Verify weighted AUC is computed
+    assert isinstance(results[RELATION_WEIGHTED_AUC_DEFS.RELATION_WEIGHTED_AUC], float)
+    assert 0.0 <= results[RELATION_WEIGHTED_AUC_DEFS.RELATION_WEIGHTED_AUC] <= 1.0
+
+    # Verify weighted AUC calculation manually
+    # Each relation has 100 samples, so counts are [100, 100, 100]
+    per_relation_counts = np.array([100, 100, 100])
+    loss_weights_np = loss_weights.numpy()
+    adjusted_weights = loss_weights_np * per_relation_counts  # [100, 200, 400]
+
+    per_relation_aucs = np.array(
+        [
+            results[relation_names[0]],
+            results[relation_names[1]],
+            results[relation_names[2]],
+        ]
+    )
+
+    expected_weighted_auc = (
+        adjusted_weights * per_relation_aucs
+    ).sum() / adjusted_weights.sum()
+
+    assert np.allclose(
+        results[RELATION_WEIGHTED_AUC_DEFS.RELATION_WEIGHTED_AUC],
+        expected_weighted_auc,
+        rtol=1e-5,
+    )
+
+    # Verify that weighted AUC is different from overall AUC (due to weighting)
+    # Weighted AUC should be closer to relation 2's AUC since it has highest weight
+    # (though relation 2 has lowest AUC, so weighted AUC should be lower than overall)
+    assert (
+        results[RELATION_WEIGHTED_AUC_DEFS.RELATION_WEIGHTED_AUC]
+        != results[METRICS.AUC]
+    )
+
+
+def test_relation_weighted_auc_with_relation_manager():
+    """Test RelationWeightedAUC with a relation manager for human-readable names."""
+
+    # Set random seed for reproducibility
+    np.random.seed(42)
+    torch.manual_seed(42)
+
+    # Create 3 relations with 50 positive and 50 negative examples each
+    num_relations = 3
+    num_samples_per_relation = 100
+
+    # Create relation types
+    relation_type = torch.repeat_interleave(
+        torch.arange(num_relations), num_samples_per_relation
+    )
+
+    # Create simple y_true and y_pred
+    y_true = np.zeros(num_relations * num_samples_per_relation, dtype=np.float32)
+    for rel_idx in range(num_relations):
+        start_idx = rel_idx * num_samples_per_relation
+        y_true[start_idx : start_idx + 50] = 1.0
+
+    y_pred = np.random.rand(num_relations * num_samples_per_relation).astype(np.float32)
+
+    # Create loss weights
+    loss_weights = torch.tensor([1.0, 2.0, 4.0], dtype=torch.float32)
+    loss_weight_alpha = 0.5
+
+    # Create relation manager with custom names (label_names must be a dict)
+    relation_names = {0: "catalysis", 1: "interaction", 2: "inhibition"}
+    relation_manager = LabelingManager(
+        label_attribute=STRATIFICATION_DEFS.EDGE_STRATA,
+        exclude_vertex_attributes=[],
+        augment_summary_types=[],
+        label_names=relation_names,
+    )
+
+    # Create RelationWeightedAUC instance with relation manager
+    rw_auc = RelationWeightedAUC(
+        loss_weights=loss_weights,
+        loss_weight_alpha=loss_weight_alpha,
+        relation_manager=relation_manager,
+    )
+
+    # Compute metrics
+    results = rw_auc.compute(y_true, y_pred, relation_type)
+
+    # Verify results use human-readable names
+    assert METRICS.AUC in results
+    assert RELATION_WEIGHTED_AUC_DEFS.RELATION_WEIGHTED_AUC in results
+    relation_names = {
+        RELATION_WEIGHTED_AUC_DEFS.RELATION_AUC_TEMPLATE.format(relation_name=name)
+        for name in relation_names.values()
+    }
+
+    for name in relation_names:
+        assert name in results
+
+    # Verify old numeric keys are not present
+    assert "auc_0" not in results
+    assert "auc_1" not in results
+    assert "auc_2" not in results

--- a/src/tests/test_napistu_data.py
+++ b/src/tests/test_napistu_data.py
@@ -396,6 +396,10 @@ def test_trim_no_relation_type(edge_prediction_with_sbo_relations):
     # Verify relation_type is removed
     assert not hasattr(trimmed, NAPISTU_DATA.RELATION_TYPE)
 
+    # Verify relation_manager is also removed when relation_type is not kept
+    assert hasattr(edge_prediction_with_sbo_relations, NAPISTU_DATA.RELATION_MANAGER)
+    assert not hasattr(trimmed, NAPISTU_DATA.RELATION_MANAGER)
+
     # Verify core attributes are still present
     assert hasattr(trimmed, PYG.X)
     assert hasattr(trimmed, PYG.EDGE_INDEX)
@@ -417,9 +421,43 @@ def test_trim_keep_relation_type(edge_prediction_with_sbo_relations):
     assert trimmed.relation_type is not None
     assert torch.equal(trimmed.relation_type, original_relation_type)
 
+    # Verify relation_manager is also preserved when relation_type is kept
+    original_relation_manager = getattr(
+        edge_prediction_with_sbo_relations, NAPISTU_DATA.RELATION_MANAGER
+    )
+    assert original_relation_manager is not None
+    assert hasattr(trimmed, NAPISTU_DATA.RELATION_MANAGER)
+    assert trimmed.relation_manager is not None
+    assert trimmed.relation_manager is original_relation_manager
+
     # Verify get_num_relations still works
     num_relations = trimmed.get_num_relations()
     assert num_relations > 0
+
+
+def test_trim_keep_labels(species_type_prediction_napistu_data):
+    """Test trim method with keep_labels=True preserves labels and labeling_manager."""
+    # Verify original data has labels
+    assert hasattr(species_type_prediction_napistu_data, PYG.Y)
+    original_labels = species_type_prediction_napistu_data.y
+    assert original_labels is not None
+
+    # Trim with keep_labels=True (default)
+    trimmed = species_type_prediction_napistu_data.trim(keep_labels=True)
+
+    # Verify labels are preserved
+    assert hasattr(trimmed, PYG.Y)
+    assert trimmed.y is not None
+    assert torch.equal(trimmed.y, original_labels)
+
+    # Verify labeling_manager is also preserved when labels are kept
+    original_labeling_manager = getattr(
+        species_type_prediction_napistu_data, NAPISTU_DATA.LABELING_MANAGER
+    )
+    assert original_labeling_manager is not None
+    assert hasattr(trimmed, NAPISTU_DATA.LABELING_MANAGER)
+    assert trimmed.labeling_manager is not None
+    assert trimmed.labeling_manager is original_labeling_manager
 
 
 def test_estimate_memory_footprint(napistu_data):

--- a/src/tests/test_tasks_edge_prediction.py
+++ b/src/tests/test_tasks_edge_prediction.py
@@ -1,0 +1,134 @@
+"""Tests for edge prediction task functions."""
+
+import torch
+
+from napistu_torch.ml.constants import TRAINING
+from napistu_torch.models.constants import ENCODERS, HEADS
+from napistu_torch.models.heads import Decoder
+from napistu_torch.models.message_passing_encoder import MessagePassingEncoder
+from napistu_torch.tasks.constants import EDGE_PREDICTION_BATCH
+from napistu_torch.tasks.edge_prediction import EdgePredictionTask, get_relation_weights
+
+
+def _normalize_to_mean_one(weights: torch.Tensor) -> torch.Tensor:
+    """Normalize weights to have mean=1.0."""
+    return weights * (len(weights) / weights.sum())
+
+
+def test_get_relation_weights():
+    """Test get_relation_weights with different alpha values.
+
+    Tests with category counts [1, 4, 9, 16]:
+    - alpha=0: all weights = 1.0 (uniform)
+    - alpha=0.5: normalized weights proportional to [1, 2, 3, 4]
+    - alpha=1: normalized weights proportional to [1, 0.25, 1/9, 1/16]
+
+    The function computes: weights = 1.0 / (counts ** alpha), then normalizes to mean=1.0.
+    """
+    # Category counts: [1, 4, 9, 16]
+    counts = torch.tensor([1, 4, 9, 16], dtype=torch.long)
+
+    # Test alpha = 0: uniform weighting (all weights = 1.0)
+    weights_0 = get_relation_weights(counts, alpha=0.0)
+    assert torch.allclose(weights_0, torch.ones(4), rtol=1e-5)
+    assert torch.allclose(weights_0.mean(), torch.tensor(1.0), rtol=1e-5)
+
+    # Test alpha = 0.5
+    # User expects normalized weights proportional to [1, 2, 3, 4]
+    weights_05 = get_relation_weights(counts, alpha=0.5)
+    assert torch.allclose(weights_05.mean(), torch.tensor(1.0), rtol=1e-5)
+    expected_05 = torch.tensor([1.0, 0.5, 1 / 3, 0.25], dtype=torch.float32)
+    expected_05_normalized = _normalize_to_mean_one(expected_05)
+    assert torch.allclose(weights_05, expected_05_normalized, rtol=1e-5)
+
+    # Test alpha = 1.0: inverse frequency
+    # User expects normalized weights proportional to [1, 0.25, 1/9, 1/16]
+    weights_1 = get_relation_weights(counts, alpha=1.0)
+    assert torch.allclose(weights_1.mean(), torch.tensor(1.0), rtol=1e-5)
+    expected_1 = torch.tensor([1.0, 0.25, 1 / 9, 1 / 16], dtype=torch.float32)
+    expected_1_normalized = _normalize_to_mean_one(expected_1)
+    assert torch.allclose(weights_1, expected_1_normalized, rtol=1e-5)
+
+    # Verify that weights are in correct order (first category gets highest weight)
+    assert weights_1[0] > weights_1[1] > weights_1[2] > weights_1[3]
+    assert weights_05[0] > weights_05[1] > weights_05[2] > weights_05[3]
+
+
+def test_edge_prediction_task_lazy_initialization(edge_prediction_with_sbo_relations):
+    """Test that EdgePredictionTask lazily initializes negative sampler and relation weights."""
+    # Create encoder and head
+    encoder = MessagePassingEncoder(
+        in_channels=edge_prediction_with_sbo_relations.num_node_features,
+        hidden_channels=32,
+        num_layers=2,
+        encoder_type=ENCODERS.SAGE,
+    )
+    # Use Decoder class (not raw head) for Test 1 - non-relation-aware head
+    head1 = Decoder(hidden_channels=32, head_type=HEADS.DOT_PRODUCT)
+
+    # Test 1: Negative sampler initialization (without relation weights)
+    task1 = EdgePredictionTask(encoder, head1, weight_loss_by_relation_frequency=False)
+
+    # Before prepare_batch: sampler should not be initialized
+    assert task1.negative_sampler is None
+    assert not task1._sampler_initialized
+    assert not task1._relation_weights_initialized
+
+    # Call prepare_batch - should trigger lazy initialization
+    batch = task1.prepare_batch(
+        edge_prediction_with_sbo_relations, split=TRAINING.TRAIN
+    )
+
+    # After prepare_batch: sampler should be initialized
+    assert task1.negative_sampler is not None
+    assert task1._sampler_initialized
+    # Relation weights should be initialized to None (since weighting is disabled)
+    assert task1._relation_weights_initialized
+    assert task1._relation_weights is None
+
+    # Verify batch was created successfully
+    assert EDGE_PREDICTION_BATCH.POS_EDGES in batch
+    assert EDGE_PREDICTION_BATCH.NEG_EDGES in batch
+
+    # Test 2: Relation weights initialization (with relation data)
+    head2 = Decoder(
+        hidden_channels=32, head_type=HEADS.DOT_PRODUCT
+    )  # relatons should be initialized if used for scoring even for non-relation-aware head
+    task2 = EdgePredictionTask(
+        encoder, head2, weight_loss_by_relation_frequency=True, loss_weight_alpha=0.5
+    )
+
+    # Before prepare_batch: nothing should be initialized
+    assert task2.negative_sampler is None
+    assert not task2._sampler_initialized
+    assert not task2._relation_weights_initialized
+
+    # Call prepare_batch with data that has relations
+    batch2 = task2.prepare_batch(
+        edge_prediction_with_sbo_relations, split=TRAINING.TRAIN
+    )
+
+    # After prepare_batch: both sampler and relation weights should be initialized
+    assert task2.negative_sampler is not None
+    assert task2._sampler_initialized
+    assert task2._relation_weights_initialized
+    assert task2._relation_weights is not None
+    assert isinstance(task2._relation_weights, torch.Tensor)
+    # Relation weights should have mean=1.0 (normalized)
+    assert torch.allclose(task2._relation_weights.mean(), torch.tensor(1.0), rtol=1e-5)
+
+    # Verify batch was created successfully
+    assert EDGE_PREDICTION_BATCH.POS_EDGES in batch2
+    assert EDGE_PREDICTION_BATCH.NEG_EDGES in batch2
+
+    # Test 3: Multiple calls to prepare_batch should not re-initialize
+    # (idempotency)
+    original_sampler = task2.negative_sampler
+    original_weights = task2._relation_weights.clone()
+
+    # Call prepare_batch again
+    _ = task2.prepare_batch(edge_prediction_with_sbo_relations, split=TRAINING.TRAIN)
+
+    # Sampler and weights should be the same objects (not re-initialized)
+    assert task2.negative_sampler is original_sampler
+    assert torch.equal(task2._relation_weights, original_weights)


### PR DESCRIPTION
- added `weight_loss_by_relation_frequency` to task config. this allows loss to be calculated up-weighting rare relation types. The main modifications needed for this are:
    - updated trimming procedure to retain relations if using a relation-weighted loss even if a relation-aware head is not used.
    - `_ensure_relation_weights` runs lazily to calculate the weight for each relation_type. Depending on the value of an alpha parameter this can vary between 1/sqrt(N) (alpha = 0.5; default), unweighted (alpha = 0) or inverse-frequency weighting (1/N; alpha = 1)
    - `_get_edge_weights` takes relation_types for positive and negative edges and calculated there multiplier.
    - Unreduced BCE is calculated and then reweighted and mean aggregated to calculate the overall loss. Closes #91 
- Created a custom metric `RelationWeightedAUC` in ml/metrics.py for calculating AUC separately for each relation_type and then aggregating them into a weighted AUC.