### PR TITLE
Issue 136 - added and tested RemoteEvaluationManager class

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu-torch
-version = 0.3.3
+version = 0.3.4
 description = PyTorch-based toolkit for working with Napistu network graphs
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
- `RunManifest.from_huggingface` classmethod loads the run_info (WandB metrics + entity, run_id, project) which with ExperimentConfig is sufficien to create the RunManifest.
- `RemoteEvaluationManager` loads a model from HF and optionally creates a NapistuDataStore from HF as well.
- Updated `HFModelLoader` with methods to load a model's `RunInfo`.
- Closes #136 