### PR TITLE
Issue 153 - `get_specific_attentions` methods for `FoundationModels` and `FoundationModels`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu-torch
-version = 0.3.6
+version = 0.3.7
 description = PyTorch-based toolkit for working with Napistu network graphs
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu_torch/configs.py
+++ b/src/napistu_torch/configs.py
@@ -1,3 +1,28 @@
+"""
+Configuration classes for Napistu-Torch experiments.
+
+This module provides Pydantic-based configuration classes for defining
+experiments, data loading, model architecture, tasks, training, and
+Weights & Biases integration.
+
+Classes
+-------
+DataConfig
+    Data loading and splitting configuration.
+ModelConfig
+    Model architecture and component configuration.
+TaskConfig
+    Task-specific configuration.
+TrainingConfig
+    Training hyperparameters and settings.
+WandBConfig
+    Weights & Biases integration configuration.
+ExperimentConfig
+    Complete experiment configuration combining all component configs.
+RunManifest
+    Manifest tracking experiment run metadata and artifacts.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/src/napistu_torch/data/compare_napistu_data.py
+++ b/src/napistu_torch/data/compare_napistu_data.py
@@ -4,6 +4,11 @@ Utilities for comparing and validating NapistuData compatibility.
 This module provides functions for validating that two NapistuData objects
 are compatible for training/inference, including feature alignment, split
 consistency, and structural compatibility checks.
+
+Public Functions
+----------------
+validate_same_data(current_summary, reference_summary, allow_missing_keys=None, verbose=False)
+    Validate that data summaries from reference and current data are compatible.
 """
 
 import logging

--- a/src/napistu_torch/data/data_utils.py
+++ b/src/napistu_torch/data/data_utils.py
@@ -1,9 +1,14 @@
-# In src/napistu_torch/data/data_utils.py
-
 """
 Utility functions for data loading and batching.
 
 Contains shared helpers for DataLoaders and collate functions.
+
+Public Functions
+----------------
+identity_collate(batch)
+    Custom collate function that returns NapistuData unchanged.
+create_single_graph_dataloader(data, batch_size=1, shuffle=False, **kwargs)
+    Create a DataLoader for a single NapistuData object.
 """
 
 from typing import List

--- a/src/napistu_torch/data/dataset.py
+++ b/src/napistu_torch/data/dataset.py
@@ -1,5 +1,16 @@
-# src/napistu_torch/data/dataset.py
-"""Datasets for edge prediction training."""
+"""
+Datasets for edge prediction training.
+
+This module provides PyTorch Dataset classes for working with NapistuData
+objects in training pipelines.
+
+Classes
+-------
+SingleGraphDataset
+    Wrapper to make a single NapistuData object work with DataLoader.
+EdgeBatchDataset
+    Dataset that splits edge indices into mini-batches for training.
+"""
 
 import torch
 from torch.utils.data import Dataset

--- a/src/napistu_torch/evaluation/edge_prediction.py
+++ b/src/napistu_torch/evaluation/edge_prediction.py
@@ -1,3 +1,17 @@
+"""
+Edge prediction evaluation utilities.
+
+This module provides functions for evaluating edge prediction performance
+stratified by edge types or other edge attributes.
+
+Public Functions
+----------------
+summarize_edge_predictions_by_strata(edge_predictions, edge_strata)
+    Summarize edge prediction performance by strata.
+plot_edge_predictions_by_strata(df, x_col=None, y_col=None, y_lower_col=None, y_upper_col=None, count_col=None, figsize=(8, 6))
+    Create a scatter plot showing prediction probabilities vs. enrichment with error bars.
+"""
+
 from typing import List, Union
 
 import matplotlib.pyplot as plt

--- a/src/napistu_torch/evaluation/edge_weights.py
+++ b/src/napistu_torch/evaluation/edge_weights.py
@@ -1,3 +1,19 @@
+"""
+Edge weight sensitivity analysis utilities.
+
+This module provides functions for analyzing how edge features influence
+learned edge weights through gradient-based sensitivity analysis.
+
+Public Functions
+----------------
+compute_edge_feature_sensitivity(edge_encoder, edge_attr, max_edges, device=None)
+    Compute mean edge-weight gradients with respect to edge features.
+format_edge_feature_sensitivity(sensitivity, feature_names, top_k=10)
+    Format sensitivity results as a DataFrame with feature names and rankings.
+plot_edge_feature_sensitivity(sensitivity, feature_names, top_k=10, figsize=(10, 6))
+    Create a horizontal bar plot showing top-k most sensitive edge features.
+"""
+
 from typing import Optional, Union
 
 import matplotlib.pyplot as plt

--- a/src/napistu_torch/evaluation/manager.py
+++ b/src/napistu_torch/evaluation/manager.py
@@ -1,4 +1,23 @@
-"""Manager for organizing experiments' metadata, data, models, and evaluation results."""
+"""
+Manager for organizing experiments' metadata, data, models, and evaluation results.
+
+This module provides managers for accessing experiment artifacts, loading models,
+and managing experiment metadata for both local and remote (HuggingFace) experiments.
+
+Classes
+-------
+EvaluationManager
+    Base class for evaluation managers.
+LocalEvaluationManager
+    Manager for local experiments with file system access.
+RemoteEvaluationManager
+    Manager for remote experiments stored on HuggingFace Hub.
+
+Public Functions
+----------------
+find_best_checkpoint(checkpoint_dir)
+    Find the best checkpoint in a directory based on validation metrics.
+"""
 
 from __future__ import annotations
 

--- a/src/napistu_torch/evaluation/model_comparison.py
+++ b/src/napistu_torch/evaluation/model_comparison.py
@@ -1,4 +1,14 @@
-"""Functions for comparing model's vertex embeddings."""
+"""
+Functions for comparing model's vertex embeddings.
+
+This module provides utilities for comparing vertex embeddings across
+different models using distance-based metrics.
+
+Public Functions
+----------------
+compare_embeddings(embeddings, device)
+    Compare the vertex embeddings of multiple models.
+"""
 
 import logging
 from itertools import combinations

--- a/src/napistu_torch/evaluation/pathways.py
+++ b/src/napistu_torch/evaluation/pathways.py
@@ -1,3 +1,17 @@
+"""
+Pathway evaluation utilities.
+
+This module provides functions for evaluating how well learned embeddings
+capture biological pathway structure through similarity analysis.
+
+Public Functions
+----------------
+calculate_pathway_similarities(embedding_matrix, pathway_assignments, pathway_names, filtering_mask=None, priority_pathways=None, device=None)
+    Calculate pathway similarity based on average within-category cosine similarity.
+get_comprehensive_source_membership(sbml_dfs, napistu_graph, pathway_names=None, vertex_summaries=None)
+    Get comprehensive pathway membership information for vertices.
+"""
+
 from typing import Optional
 
 import numpy as np

--- a/src/napistu_torch/evaluation/relation_prediction.py
+++ b/src/napistu_torch/evaluation/relation_prediction.py
@@ -1,4 +1,21 @@
-"""Evaluation functions for relation prediction and relation-stratified loss."""
+"""
+Evaluation functions for relation prediction and relation-stratified loss.
+
+This module provides functions for evaluating relation prediction performance,
+including confusion matrices, correlation analysis, and comparison with
+external truth datasets like PerturbSeq.
+
+Public Functions
+----------------
+calculate_relation_type_confusion_and_correlation(model, napistu_data, normalize='true')
+    Calculate the confusion matrix for the relation types in the test set.
+compare_relation_type_predictions_to_perturbseq_truth(model, relation_type_indices, perturbseq_edgelist_tensor, napistu_data, distinct_perturbseq_pairs, distinct_harmonizome_perturbseq_interactions, perturbseq_order, relation_type_order, normalize=None, device=None)
+    Compare model predictions to PerturbSeq truth data.
+get_perturbseq_edgelist_tensor(distinct_perturbseq_pairs, napistu_data)
+    Convert PerturbSeq edge list to tensor format aligned with NapistuData.
+summarize_relation_type_aucs(relation_type_aucs, relation_type_order)
+    Summarize relation type AUCs as a DataFrame.
+"""
 
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/src/napistu_torch/load/artifacts.py
+++ b/src/napistu_torch/load/artifacts.py
@@ -5,6 +5,24 @@ This module defines all standard artifacts that can be created from SBML_dfs
 and NapistuGraph objects. Each artifact has a creation function that encapsulates
 the ETL logic.
 
+Classes
+-------
+ArtifactDefinition
+    Definition of an artifact that can be created from SBML_dfs and NapistuGraph.
+
+Public Functions
+----------------
+create_artifact(name, sbml_dfs, napistu_graph, artifact_registry=None)
+    Create an artifact by name using the registry.
+ensure_stratify_by_artifact_name(stratify_by)
+    Ensure the stratify_by value is an artifact name.
+get_artifact_info(name, artifact_registry=None)
+    Get information about an artifact.
+list_available_artifacts(artifact_registry=None)
+    List all available artifact names in the registry.
+validate_artifact_registry(artifact_registry)
+    Validate the artifact registry.
+
 To add a new artifact:
 1. Create a creation function (e.g., create_my_artifact)
 2. Add an ArtifactDefinition to _ARTIFACTS list

--- a/src/napistu_torch/load/checkpoints.py
+++ b/src/napistu_torch/load/checkpoints.py
@@ -2,6 +2,25 @@
 Checkpoint loading and validation utilities.
 
 This module provides utilities for loading and validating pretrained Napistu-Torch models.
+
+Classes
+-------
+Checkpoint
+    Manager for PyTorch Lightning checkpoint loading and validation.
+DataMetadata
+    Metadata about the NapistuData used during training.
+EdgeEncoderMetadata
+    Metadata about the edge encoder component.
+EncoderMetadata
+    Metadata about the encoder component.
+HeadMetadata
+    Metadata about the head component.
+ModelMetadata
+    Metadata about the complete model architecture.
+CheckpointHyperparameters
+    Hyperparameters stored in the checkpoint.
+CheckpointStructure
+    Structure definition for checkpoint validation.
 """
 
 import logging

--- a/src/napistu_torch/load/constants.py
+++ b/src/napistu_torch/load/constants.py
@@ -243,3 +243,13 @@ FM_DEFS = SimpleNamespace(
     WEIGHTS_TEMPLATE="{prefix}_weights.npz",
     METADATA_TEMPLATE="{prefix}_metadata.json",
 )
+
+FM_EDGELIST = SimpleNamespace(
+    FROM_GENE="from_gene",
+    TO_GENE="to_gene",
+    FROM_IDX="from_idx",
+    TO_IDX="to_idx",
+    LAYER="layer",
+    ATTENTION="attention",
+    MODEL="model",
+)

--- a/src/napistu_torch/load/encoders.py
+++ b/src/napistu_torch/load/encoders.py
@@ -1,4 +1,18 @@
-"""Custom transformations for NapistuGraph vertex and edge features"""
+"""Custom transformations for NapistuGraph vertex and edge features.
+
+This module provides custom sklearn-compatible transformers for encoding
+sparse continuous features and other specialized transformations.
+
+Classes
+-------
+SparseContScaler
+    Transformer for encoding sparse continuous features as indicator + standardized value pairs.
+
+Public Functions
+----------------
+encode_sparse_continuous(values, scaler=None, fit=True)
+    Encode sparse continuous features as indicator + standardized value pairs.
+"""
 
 import numpy as np
 import pandas as pd

--- a/src/napistu_torch/load/encoding.py
+++ b/src/napistu_torch/load/encoding.py
@@ -1,3 +1,30 @@
+"""DataFrame encoding and transformation utilities.
+
+This module provides functions for automatically selecting encodings, fitting
+transformers, and transforming DataFrames for use in machine learning pipelines.
+
+Public Functions
+----------------
+auto_encode(graph_df, existing_encodings, encoders=DEFAULT_ENCODERS)
+    Select appropriate encodings for each column in a graph dataframe.
+classify_encoding(series, max_categories=50)
+    Classify the appropriate encoding type for a pandas Series.
+compose_encoding_configs(config1, config2)
+    Compose two encoding configurations.
+deduplicate_features(feature_names)
+    Deduplicate feature names by grouping identical features.
+config_to_column_transformer(config, encoders=DEFAULT_ENCODERS)
+    Convert encoding config to sklearn ColumnTransformer.
+encode_dataframe(df, config, encoders=DEFAULT_ENCODERS, fit=True)
+    Encode a DataFrame using the specified configuration.
+expand_deduplicated_features(feature_names, feature_name_aliases)
+    Expand deduplicated feature names using aliases.
+fit_encoders(df, config, encoders=DEFAULT_ENCODERS)
+    Fit encoders on a DataFrame using the specified configuration.
+transform_dataframe(df, preprocessor, feature_names)
+    Transform a DataFrame using a fitted preprocessor.
+"""
+
 import logging
 from typing import Dict, List, Optional, Tuple, Union
 

--- a/src/napistu_torch/load/encoding_manager.py
+++ b/src/napistu_torch/load/encoding_manager.py
@@ -1,4 +1,24 @@
-"""Configuration management for DataFrame encoding transformations."""
+"""Configuration management for DataFrame encoding transformations.
+
+This module provides configuration management for DataFrame encoding transformations,
+allowing flexible specification of how columns should be encoded.
+
+Classes
+-------
+EncodingManager
+    Configuration manager for DataFrame encoding transformations.
+TransformConfig
+    Configuration for a single transform.
+EncodingConfig
+    Complex encoding configuration format.
+SimpleEncodingConfig
+    Simple encoding configuration format.
+
+Public Functions
+----------------
+detect_config_format(config)
+    Detect whether a config dict is in simple or complex format.
+"""
 
 import logging
 from collections import defaultdict

--- a/src/napistu_torch/load/gcs.py
+++ b/src/napistu_torch/load/gcs.py
@@ -1,4 +1,13 @@
-"""Module for loading pathway representations from GCS"""
+"""Module for loading pathway representations from GCS.
+
+This module provides utilities for downloading Napistu models from Google Cloud Storage
+and initializing NapistuDataStore objects.
+
+Public Functions
+----------------
+gcs_model_to_store(napistu_data_dir, store_dir, asset_name=GCS_ASSETS_NAMES.HUMAN_CONSENSUS, asset_version=None, overwrite_data_dir=False, overwrite_store_dir=False)
+    Download a model from GCS and save it to a local directory to initialize a NapistuDataStore.
+"""
 
 import logging
 import os

--- a/src/napistu_torch/load/napistu_graphs.py
+++ b/src/napistu_torch/load/napistu_graphs.py
@@ -1,3 +1,20 @@
+"""NapistuGraph to NapistuData conversion utilities.
+
+This module provides functions for converting NapistuGraph objects to NapistuData
+objects with various configurations and masking strategies.
+
+Public Functions
+----------------
+augment_napistu_graph(sbml_dfs, napistu_graph, sbml_dfs_summary_types=None, ignored_attributes=None, ignored_if_constant_attributes=None, inplace=False)
+    Augment a NapistuGraph with additional vertex and edge attributes from SBML_dfs.
+construct_vertex_labeled_napistu_data(sbml_dfs, napistu_graph, splitting_strategy=SPLITTING_STRATEGIES.VERTEX_MASK, label_type=LABEL_TYPE.SPECIES_TYPE, task_type=TASK_TYPES.CLASSIFICATION, name=None, **kwargs)
+    Construct a NapistuData object with vertex labels from a NapistuGraph.
+construct_unlabeled_napistu_data(sbml_dfs, napistu_graph, splitting_strategy=SPLITTING_STRATEGIES.NO_MASK, name=None, **kwargs)
+    Construct an unlabeled NapistuData object from a NapistuGraph.
+napistu_graph_to_napistu_data(napistu_graph, splitting_strategy, vertex_default_transforms=None, edge_default_transforms=None, labels=None, relation_type=None, name=None, **kwargs)
+    Convert a NapistuGraph to a NapistuData object with optional labels and transforms.
+"""
+
 import inspect
 import logging
 from typing import Any, Callable, Dict, Optional, Union

--- a/src/napistu_torch/load/stratification.py
+++ b/src/napistu_torch/load/stratification.py
@@ -1,3 +1,20 @@
+"""Stratification utilities for edge splitting.
+
+This module provides functions for creating composite edge strata and managing
+stratification for train/test/val splitting.
+
+Public Functions
+----------------
+create_composite_edge_strata(napistu_graph, stratify_by=STRATIFY_BY.NODE_SPECIES_TYPE)
+    Create a composite edge attribute by concatenating the endpoint attributes.
+ensure_strata_series(edge_strata)
+    Ensure edge_strata is a pandas Series, converting from DataFrame if needed.
+merge_rare_strata(edge_strata, min_count, other_category_name='rare')
+    Merge rare strata into a single category.
+validate_edge_strata_alignment(napistu_data, edge_strata)
+    Validate that strata series is aligned with NapistuData edge_index.
+"""
+
 import logging
 from typing import Optional, Union
 

--- a/src/napistu_torch/ml/hugging_face.py
+++ b/src/napistu_torch/ml/hugging_face.py
@@ -81,7 +81,7 @@ class HFClient:
     _validate_repo_id(repo_id) : None
         Validate repository ID format
     """
-    
+
     # Class-level cache to avoid repeated authentication checks
     _auth_validated: bool = False
     _last_token: Optional[str] = None

--- a/src/napistu_torch/models/edge_encoder.py
+++ b/src/napistu_torch/models/edge_encoder.py
@@ -2,6 +2,11 @@
 Edge encoder for Napistu-Torch.
 
 This module provides a simple MLP-based edge encoder for learning edge importance weights.
+
+Classes
+-------
+EdgeEncoder
+    Learns edge importance weights from edge features.
 """
 
 from typing import Any, Dict

--- a/src/napistu_torch/models/head_utils.py
+++ b/src/napistu_torch/models/head_utils.py
@@ -1,4 +1,17 @@
-"""Utility functions supporting a subset of heads."""
+"""Utility functions supporting a subset of heads.
+
+This module provides utility functions for computing distances and probabilities
+used by various prediction heads, particularly relation-aware heads like RotatE.
+
+Public Functions
+----------------
+compute_rotate_distance(head_embeddings, tail_embeddings, relation_phase, eps=1e-10)
+    Compute RotatE distance in complex space.
+normalized_distances_to_probs(scores)
+    Convert distances between softmax-normalized vectors to probabilities.
+validate_symmetric_relation_indices(symmetric_relation_indices, num_relations)
+    Validate that symmetric relation indices are properly configured.
+"""
 
 from typing import List, Union
 

--- a/src/napistu_torch/models/heads.py
+++ b/src/napistu_torch/models/heads.py
@@ -3,6 +3,33 @@ Prediction heads for Napistu-Torch.
 
 This module provides implementations of different prediction heads for various tasks
 like edge prediction, node classification, etc. All heads follow a consistent interface.
+
+Classes
+-------
+AttentionHead
+    Lightweight attention head for edge prediction.
+ConditionalRotatEHead
+    Conditional RotatE head for relation-aware edge prediction.
+DistMultHead
+    DistMult head for relation-aware edge prediction.
+DotProductHead
+    Simple dot product head for edge prediction.
+EdgeMLPHead
+    MLP-based head for edge prediction.
+NodeClassificationHead
+    Head for node classification tasks.
+RelationAttentionHead
+    Relation-aware attention head for edge prediction.
+RelationGatedMLPHead
+    Relation-aware gated MLP head for edge prediction.
+RelationAttentionMLPHead
+    Relation-aware attention-MLP hybrid head for edge prediction.
+RotatEHead
+    RotatE head for relation-aware edge prediction.
+TransEHead
+    TransE head for relation-aware edge prediction.
+Decoder
+    Decoder combining encoder and head for complete model architecture.
 """
 
 from typing import Any, Dict, List, Optional

--- a/src/napistu_torch/models/message_passing_encoder.py
+++ b/src/napistu_torch/models/message_passing_encoder.py
@@ -1,8 +1,13 @@
 """
-Graph Neural Network models for Napistu-Torch
+Graph Neural Network models for Napistu-Torch.
 
-Removed edge_weight parameter since it's not used for message passing.
-Edge weights are stored in edge attributes for supervision, not encoding.
+This module provides a unified Graph Neural Network encoder supporting multiple
+architectures (GCN, GAT, SAGE, GraphConv) with consistent behavior and configuration.
+
+Classes
+-------
+MessagePassingEncoder
+    Unified Graph Neural Network encoder supporting multiple architectures.
 """
 
 import logging

--- a/src/napistu_torch/models/node2vec.py
+++ b/src/napistu_torch/models/node2vec.py
@@ -1,3 +1,19 @@
+"""
+Node2Vec utilities for Napistu-Torch.
+
+This module provides utility functions for creating and training Node2Vec models
+for unsupervised node embedding learning.
+
+Public Functions
+----------------
+get_node2vec_model(napistu_data, device)
+    Create a Node2Vec model configured for Napistu data.
+get_node2vec_training_regime(model)
+    Get DataLoader and Optimizer for training a Node2Vec model.
+get_node2vec_training_loop(model, loader, optimizer, device)
+    Execute a single training epoch for Node2Vec.
+"""
+
 import sys
 
 import torch

--- a/src/napistu_torch/napistu_data.py
+++ b/src/napistu_torch/napistu_data.py
@@ -1,8 +1,13 @@
 """
 NapistuData - A PyTorch Geometric Data subclass for Napistu networks.
 
-This class extends PyG's Data class with Napistu-specific functionality
-including safe save/load methods and additional utilities.
+This module provides a PyTorch Geometric Data subclass with Napistu-specific
+functionality including safe save/load methods and additional utilities.
+
+Classes
+-------
+NapistuData
+    A PyTorch Geometric Data subclass for Napistu biological networks.
 """
 
 import copy

--- a/src/napistu_torch/napistu_data_store.py
+++ b/src/napistu_torch/napistu_data_store.py
@@ -1,3 +1,15 @@
+"""
+NapistuDataStore - Management system for Napistu data objects.
+
+This module provides a store system for managing NapistuData, VertexTensor,
+and pandas DataFrame objects related to a single SBML_dfs/NapistuGraph pair.
+
+Classes
+-------
+NapistuDataStore
+    Manage data objects related to a single SBML_dfs/NapistuGraph pair.
+"""
+
 import json
 import logging
 import shutil

--- a/src/napistu_torch/vertex_tensor.py
+++ b/src/napistu_torch/vertex_tensor.py
@@ -1,3 +1,15 @@
+"""
+VertexTensor - Container for vertex-aligned tensors with metadata.
+
+This module provides a container class for storing vertex-aligned tensors
+with metadata to validate alignment and interpret features.
+
+Classes
+-------
+VertexTensor
+    Container for vertex-aligned tensors with metadata.
+"""
+
 import logging
 from pathlib import Path
 from typing import List, Optional, Union


### PR DESCRIPTION
- `get_specific_attentions` allows specific gene-gene pairs to be extracted. This is directly used in FoundationModels.get_top_attentions to find the top-attention edges by layer and then extracting the same pairs in all models and layers. Closes #153 
- misc module-level docstrings with classes and public functions