### PR TITLE
Issue 157 - rank-based summaries of topK agreement between models and layers

### DIFF
--- a/src/napistu_torch/load/constants.py
+++ b/src/napistu_torch/load/constants.py
@@ -251,6 +251,7 @@ FM_EDGELIST = SimpleNamespace(
     TO_IDX="to_idx",
     LAYER="layer",
     ATTENTION="attention",
+    ATTENTION_RANK="attention_rank",
     MODEL="model",
 )
 

--- a/src/napistu_torch/load/napistu_graphs.py
+++ b/src/napistu_torch/load/napistu_graphs.py
@@ -1,4 +1,5 @@
-"""NapistuGraph to NapistuData conversion utilities.
+"""
+NapistuGraph to NapistuData conversion utilities.
 
 This module provides functions for converting NapistuGraph objects to NapistuData
 objects with various configurations and masking strategies.

--- a/src/napistu_torch/utils/constants.py
+++ b/src/napistu_torch/utils/constants.py
@@ -40,3 +40,22 @@ CORRELATION_METHODS = SimpleNamespace(
     SPEARMAN="spearman",
     PEARSON="pearson",
 )
+
+STATISTICAL_TESTS = SimpleNamespace(
+    WILCOXON_RANKSUM="wilcoxon",
+    ONE_SAMPLE_TTEST="ttest_one_sample",
+)
+
+RANK_SHIFT_TESTS = {
+    STATISTICAL_TESTS.WILCOXON_RANKSUM,
+    STATISTICAL_TESTS.ONE_SAMPLE_TTEST,
+}
+
+RANK_SHIFT_SUMMARIES = SimpleNamespace(
+    MEAN_QUANTILE="mean_quantile",
+    MEDIAN_QUANTILE="median_quantile",
+    MIN_QUANTILE="min_quantile",
+    MAX_QUANTILE="max_quantile",
+    STATISTIC="statistic",
+    P_VALUE="p_value",
+)

--- a/src/napistu_torch/utils/pd_utils.py
+++ b/src/napistu_torch/utils/pd_utils.py
@@ -1,0 +1,81 @@
+"""
+Utilities for Pandas operations.
+
+Public Functions
+----------------
+calculate_ranks(df, value_col, by_absolute_value=True, grouping_vars=None)
+    Compute integer ranks for values in a DataFrame, ranking within groups.
+
+"""
+
+from typing import List, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+
+def calculate_ranks(
+    df: pd.DataFrame,
+    value_col: str,
+    by_absolute_value: bool = True,
+    grouping_vars: Optional[Union[str, List[str]]] = None,
+) -> pd.Series:
+    """
+    Compute integer ranks for values in a DataFrame, ranking within groups.
+
+    Since all entries are already top N, ranks them directly based on values
+    within each group. Rank 1 = highest value, rank 2 = second highest, etc.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing values to rank
+    value_col : str
+        Name of the column containing values to rank
+    by_absolute_value : bool, optional
+        If True, rank by absolute value (default: True).
+        If False, rank by raw value.
+    grouping_vars : str or List[str], optional
+        Column name(s) to group by when calculating ranks. If None, ranks globally.
+        If a single string, ranks within each value of that column.
+        If a list of strings, ranks within each combination of those columns.
+        Example: ['model'] or ['model', 'layer'] (default: None)
+
+    Returns
+    -------
+    pd.Series
+        Series of integer ranks with same index as df.
+        Rank 1 = highest value, rank 2 = second highest, etc.
+        Ranks are calculated within each group if grouping_vars is provided.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({
+    ...     'model': ['A', 'A', 'B', 'B'],
+    ...     'attention': [0.9, 0.8, 0.7, 0.6]
+    ... })
+    >>> ranks = calculate_ranks(df, 'attention', grouping_vars='model')
+    >>> # Ranks within each model: A gets [1, 2], B gets [1, 2]
+    """
+    if by_absolute_value:
+        values_to_rank = df[value_col].abs()
+    else:
+        values_to_rank = df[value_col]
+
+    # Rank in descending order (highest = rank 1)
+    # Use method='first' to handle ties deterministically
+    if grouping_vars is not None:
+        if isinstance(grouping_vars, str):
+            grouping_vars = [grouping_vars]
+        # Convert column names to Series for groupby
+        groupby_series = [df[col] for col in grouping_vars]
+        ranks = (
+            values_to_rank.groupby(groupby_series)
+            .rank(method="first", ascending=False)
+            .astype(np.int64)
+        )
+    else:
+        ranks = values_to_rank.rank(method="first", ascending=False).astype(np.int64)
+
+    return ranks

--- a/src/napistu_torch/utils/statistics.py
+++ b/src/napistu_torch/utils/statistics.py
@@ -1,0 +1,250 @@
+"""
+Utilities for calculating statistics.
+
+Public Functions
+----------------
+calculate_rank_shift(df, n_genes, grouping_vars="layer", alternative="greater", test_method="wilcoxon")
+    Calculate rank percentile shift for a given DataFrame.
+compare_top_k_union_ranks(top_k_union, grouping_vars, defining_vars, top_k, max_rank, rank_col, test_method="wilcoxon", alternative="two-sided")
+    Calculate the rank agreement between the top-k attention pairs of a given partition and all other partitions.
+"""
+
+from typing import List, Optional, Union
+
+import pandas as pd
+from scipy.stats import ttest_1samp, wilcoxon
+
+from napistu_torch.utils.constants import (
+    RANK_SHIFT_SUMMARIES,
+    RANK_SHIFT_TESTS,
+    STATISTICAL_TESTS,
+)
+
+
+def calculate_rank_shift(
+    df: pd.DataFrame,
+    rank_col: str,
+    max_rank: int,
+    grouping_vars: Optional[Union[str, List[str]]] = None,
+    alternative: str = "two-sided",
+    test_method: str = STATISTICAL_TESTS.WILCOXON_RANKSUM,
+) -> pd.DataFrame:
+    """
+    Calculate rank shift statistics for a given DataFrame.
+
+    For each group (e.g., layer), calculates the rank shift statistics.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing rank column and grouping variable.
+    rank_col : str
+        Column name containing ranks.
+    max_rank : int
+        Maximum possible rank.
+    grouping_var : str, optional
+        Column name(s) to group by when calculating ranks. If None, ranks globally.
+        If a single string, ranks within each value of that column.
+        If a list of strings, ranks within each combination of those columns.
+        Example: ['model'] or ['model', 'layer'] (default: None)
+        Tests are performed separately for each unique value.
+    alternative : str, optional
+        Alternative hypothesis for the test (default: "greater").
+        - "greater": selected queries have higher quantiles than 0.5
+        - "less": selected queries have lower quantiles than 0.5
+        - "two-sided": selected queries differ from 0.5
+    test_method : str, optional
+        Statistical test to use (default: "wilcoxon").
+        - "wilcoxon": Wilcoxon signed-rank test (non-parametric)
+        - "ttest": One-sample t-test (parametric)
+
+    Returns
+    -------
+    pd.DataFrame
+        Results with columns:
+        - <grouping_var> : Grouping variable value
+        - n_queries : Number of queries in this group
+        - mean_quantile : Mean quantile (0.5 = null expectation)
+        - median_quantile : Median quantile
+        - statistic : Test statistic
+        - p_value : P-value for the test
+
+    Examples
+    --------
+    >>> # Test if top-k queries occupy high quantiles within each layer
+    >>> results = calculate_rank_shift(
+    ...     df=top_k_union,
+    ...     rank_col="rank",
+    ...     max_rank=len(common_ids)**2,
+    ...     grouping_var="layer"
+    ... )
+    >>> # Significant layers have p_value < 0.05
+    >>> significant = results[results['p_value'] < 0.05]
+
+    >>> # Compare across models instead of layers
+    >>> results = calculate_rank_shift(
+    ...     multi_model_edges,
+    ...     n_genes=len(common_ids),
+    ...     grouping_var="model"
+    ... )
+    """
+
+    # Validate inputs
+    if rank_col not in df.columns:
+        raise ValueError(f"DataFrame must contain '{rank_col}' column")
+    if any(df[rank_col] > max_rank):
+        raise ValueError(f"Rank values must be less than or equal to {max_rank}")
+    if any(df[rank_col] < 1):
+        raise ValueError("Rank values must be greater than or equal to 1")
+    if grouping_vars is not None:
+        if isinstance(grouping_vars, str):
+            grouping_vars = [grouping_vars]
+        for col in grouping_vars:
+            if col not in df.columns:
+                raise ValueError(f"DataFrame must contain '{col}' column")
+    if test_method not in [
+        STATISTICAL_TESTS.WILCOXON_RANKSUM,
+        STATISTICAL_TESTS.ONE_SAMPLE_TTEST,
+    ]:
+        raise ValueError(f"test_method must be one of {RANK_SHIFT_TESTS}")
+
+    if grouping_vars is None:
+        df = df.copy()
+        df["_dummy_group"] = 0
+        grouping_vars = ["_dummy_group"]
+
+    results = (
+        df.groupby(grouping_vars, group_keys=True)
+        .apply(
+            _compute_rank_shift_for_group,
+            rank_col=rank_col,
+            max_rank=max_rank,
+            alternative=alternative,
+            test_method=test_method,
+            include_groups=False,  # Don't duplicate index as columns
+        )
+        .reset_index()
+    )
+
+    # Drop dummy column if we added it
+    if "_dummy_group" in results.columns:
+        results = results.drop(columns=["_dummy_group"])
+
+    return results
+
+
+def compare_top_k_union_ranks(
+    top_k_union: pd.DataFrame,
+    grouping_vars: list,
+    defining_vars: list,
+    top_k: int,
+    max_rank: int,
+    rank_col: str,
+    test_method: str = STATISTICAL_TESTS.WILCOXON_RANKSUM,
+    alternative: str = "two-sided",
+) -> pd.DataFrame:
+    """
+    Calculate the rank agreement between the top-k attention pairs of a given partition and all other partitions.
+
+    Parameters
+    ----------
+    top_k_union : pd.DataFrame
+        The top-k attention pairs of a given partition.
+    grouping_vars : list
+        The variables to group by.
+    defining_vars : list
+        The variables to define the top-k attention pairs.
+    top_k : int
+        The number of top-k attention pairs considered (this should match the value used to create top_k_union)
+    max_rank : int
+        The maximum rank considered.
+    rank_col : str
+        The column name of the ranks.
+    test_method : str, optional
+        Statistical test to use (default: "wilcoxon").
+        - "wilcoxon": Wilcoxon signed-rank test (non-parametric)
+        - "ttest": One-sample t-test (parametric)
+    alternative : str, optional
+        Alternative hypothesis for the test (default: "two-sided").
+        - "greater": selected queries have higher quantiles than 0.5
+        - "less": selected queries have lower quantiles than 0.5
+        - "two-sided": selected queries differ from 0.5
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame containing the rank agreement between the top-k attention pairs of a given partition and all other partitions.
+    """
+    partitions = top_k_union[grouping_vars].drop_duplicates().reset_index(drop=True)
+    eval_renaming_map = {var: f"eval_{var}" for var in grouping_vars}
+    query_cols = [f"query_{var}" for var in grouping_vars]
+
+    results = []
+    for i in range(partitions.shape[0]):
+        topk_partition = partitions.iloc[[i]]  # Keep as DataFrame
+
+        topk_partition_df = top_k_union.merge(
+            topk_partition, on=grouping_vars, how="inner"
+        ).query(f"{rank_col} <= @top_k")
+
+        # Get all OTHER partitions filtered to the same gene pairs
+        other_partitions = partitions.drop(i).reset_index(drop=True)
+
+        other_partitions_df = top_k_union.merge(
+            other_partitions, on=grouping_vars, how="inner"
+        ).merge(topk_partition_df[defining_vars], on=defining_vars, how="inner")
+
+        result = (
+            calculate_rank_shift(
+                other_partitions_df,
+                rank_col=rank_col,
+                alternative=alternative,
+                test_method=test_method,
+                max_rank=max_rank,
+                grouping_vars=grouping_vars,
+            )
+            .rename(columns=eval_renaming_map)
+            .assign(
+                **{f"query_{var}": topk_partition[var].iloc[0] for var in grouping_vars}
+            )
+            .pipe(
+                lambda df: df[
+                    query_cols + [col for col in df.columns if col not in query_cols]
+                ]
+            )
+        )
+
+        results.append(result)
+
+    return pd.concat(results, ignore_index=True)
+
+
+def _compute_rank_shift_for_group(
+    group_df: pd.DataFrame,
+    rank_col: str,
+    max_rank: int,
+    alternative: str,
+    test_method: str,
+) -> pd.Series:
+    """Compute rank shift statistics for a single group."""
+    # Convert ranks to quantiles (0-1 scale)
+    quantiles = group_df[rank_col] / max_rank
+
+    # Perform test (null: quantiles centered at 0.5)
+    if test_method == STATISTICAL_TESTS.WILCOXON_RANKSUM:
+        stat, p_value = wilcoxon(quantiles - 0.5, alternative=alternative)
+    elif test_method == STATISTICAL_TESTS.ONE_SAMPLE_TTEST:
+        stat, p_value = ttest_1samp(quantiles, 0.5, alternative=alternative)
+    else:
+        raise ValueError(f"Invalid test method: {test_method}")
+
+    return pd.Series(
+        {
+            RANK_SHIFT_SUMMARIES.MEAN_QUANTILE: quantiles.mean(),
+            RANK_SHIFT_SUMMARIES.MEDIAN_QUANTILE: quantiles.median(),
+            RANK_SHIFT_SUMMARIES.MIN_QUANTILE: quantiles.min(),
+            RANK_SHIFT_SUMMARIES.MAX_QUANTILE: quantiles.max(),
+            RANK_SHIFT_SUMMARIES.STATISTIC: stat,
+            RANK_SHIFT_SUMMARIES.P_VALUE: p_value,
+        }
+    )

--- a/src/napistu_torch/utils/torch_utils.py
+++ b/src/napistu_torch/utils/torch_utils.py
@@ -1,4 +1,21 @@
-"""Utility functions for managing torch devices and memory."""
+"""
+Utility functions for managing torch devices and memory.
+
+Public Functions
+----------------
+cleanup_tensors(tensors)
+    Clean up tensors and empty cache for all unique devices they were on.
+delete_tensors(tensors)
+    Delete one or more tensors without emptying cache.
+empty_cache(device)
+    Empty the cache for a given device.
+ensure_device(device, allow_autoselect=False)
+    Ensure the device is a torch.device.
+memory_manager(device)
+    Context manager for general memory management.
+select_device(mps_valid=True)
+    Select the device to use for the model.
+"""
 
 import gc
 from contextlib import contextmanager
@@ -9,38 +26,111 @@ from torch import device as torch_device
 
 from napistu_torch.ml.constants import DEVICE
 
-# memory management utilities
-
 
 def cleanup_tensors(*tensors) -> None:
     """
-    Explicitly clean up one or more tensors and free their memory.
+    Clean up tensors and empty cache for all unique devices they were on.
+
+    Deletes the provided tensors and then calls empty_cache() for each unique
+    device that the tensors were on. This ensures GPU/MPS memory is freed immediately.
+    Non-tensor objects (e.g., DataFrames) are simply deleted without cache clearing.
+
+    Parameters
+    ----------
+    *tensors : torch.Tensor or any object
+        One or more tensors to clean up. Devices are automatically detected
+        from the tensors themselves. Non-tensor objects are deleted but don't
+        trigger cache clearing.
+
+    Examples
+    --------
+    >>> # Clean up tensors on GPU
+    >>> cleanup_tensors(attention, rank_tensor, edge_attentions)
+    >>> # Clean up tensors on different devices
+    >>> cleanup_tensors(tensor1, tensor2)  # Automatically handles both devices
+    >>> # Non-tensors are handled gracefully
+    >>> cleanup_tensors(tensor, df)  # DataFrame is deleted but doesn't affect cache
+    """
+    # Collect unique devices before deleting tensors
+    devices = set()
+    for tensor in tensors:
+        if tensor is not None:
+            # Only collect device if object has device attribute (i.e., is a tensor)
+            if hasattr(tensor, "device"):
+                devices.add(tensor.device)
+
+    # Delete tensors (and any other objects)
+    delete_tensors(*tensors)
+
+    # Empty cache for each unique device
+    for device in devices:
+        empty_cache(device)
+
+
+def delete_tensors(*tensors) -> None:
+    """
+    Delete one or more tensors without emptying cache.
 
     Parameters
     ----------
     *tensors : torch.Tensor
-        One or more tensors to clean up
+        One or more tensors to delete
     """
     for tensor in tensors:
         if tensor is not None:
             del tensor
 
 
-def empty_cache(device: torch_device) -> None:
+def empty_cache(device: Union[str, torch_device]) -> None:
     """
     Empty the cache for a given device. If the device is not MPS or GPU, do nothing.
 
     Parameters
     ----------
-    device : torch.device
-        The device to empty the cache for
+    device : str or torch.device
+        The device to empty the cache for. Can be a string like 'cuda:0' or 'mps',
+        or a torch.device object.
     """
+    # Normalize to torch.device if string
+    if isinstance(device, str):
+        device = torch_device(device)
+
     if device.type == DEVICE.MPS and backends.mps.is_available():
         mps.empty_cache()
     elif device.type == DEVICE.GPU and cuda.is_available():
         cuda.empty_cache()
 
     return None
+
+
+def ensure_device(
+    device: Optional[Union[str, torch_device]], allow_autoselect: bool = False
+) -> torch_device:
+    """
+    Ensure the device is a torch.device.
+
+    Parameters
+    ----------
+    device : Union[str, torch.device]
+        The device to ensure
+    allow_autoselect : bool
+        Whether to allow automatic selection of the device if the device is not specified
+    """
+
+    if device is None:
+        if allow_autoselect:
+            return select_device()
+        else:
+            raise ValueError("An explicit device is required but was not specified")
+
+    if isinstance(device, str):
+        return torch_device(device)
+    elif isinstance(device, torch_device):
+        return device
+    else:
+        raise ValueError(
+            f"Invalid device: {device} value, must be a string or torch.device"
+        )
 
 
 @contextmanager
@@ -72,39 +162,6 @@ def memory_manager(device: torch_device = torch_device(DEVICE.CPU)):
         empty_cache(device)
         # Force garbage collection
         gc.collect()
-
-
-# torch utils
-
-
-def ensure_device(
-    device: Optional[Union[str, torch_device]], allow_autoselect: bool = False
-) -> torch_device:
-    """
-    Ensure the device is a torch.device.
-
-    Parameters
-    ----------
-    device : Union[str, torch.device]
-        The device to ensure
-    allow_autoselect : bool
-        Whether to allow automatic selection of the device if the device is not specified
-    """
-
-    if device is None:
-        if allow_autoselect:
-            return select_device()
-        else:
-            raise ValueError("An explicit device is required but was not specified")
-
-    if isinstance(device, str):
-        return torch_device(device)
-    elif isinstance(device, torch_device):
-        return device
-    else:
-        raise ValueError(
-            f"Invalid device: {device} value, must be a string or torch.device"
-        )
 
 
 def select_device(mps_valid: bool = True):

--- a/src/tests/test_utils_pd_utils.py
+++ b/src/tests/test_utils_pd_utils.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pandas as pd
+
+from napistu_torch.utils.pd_utils import calculate_ranks
+
+
+def test_calculate_ranks():
+    """Test calculate_ranks with various scenarios."""
+    # Test 1: Basic ranking without grouping
+    df1 = pd.DataFrame({"value": [0.9, 0.8, 0.7, 0.6, 0.5]})
+    ranks1 = calculate_ranks(df1, "value", by_absolute_value=False)
+    assert ranks1.dtype == np.int64
+    assert list(ranks1) == [1, 2, 3, 4, 5]
+
+    # Test 2: Ranking with single grouping variable
+    df2 = pd.DataFrame(
+        {"model": ["A", "A", "B", "B"], "attention": [0.9, 0.8, 0.7, 0.6]}
+    )
+    ranks2 = calculate_ranks(df2, "attention", grouping_vars="model")
+    assert ranks2.iloc[0] == 1  # A, 0.9
+    assert ranks2.iloc[1] == 2  # A, 0.8
+    assert ranks2.iloc[2] == 1  # B, 0.7
+    assert ranks2.iloc[3] == 2  # B, 0.6
+
+    # Test 3: Ranking by absolute value with negative values
+    df3 = pd.DataFrame({"value": [-0.9, 0.8, -0.7, 0.6]})
+    ranks3_abs = calculate_ranks(df3, "value", by_absolute_value=True)
+    ranks3_raw = calculate_ranks(df3, "value", by_absolute_value=False)
+    assert ranks3_abs.iloc[0] == 1  # -0.9 has highest absolute value
+    assert ranks3_raw.iloc[1] == 1  # 0.8 is highest raw value
+
+    # Test 4: Multiple grouping variables
+    df4 = pd.DataFrame(
+        {
+            "model": ["A", "A", "B", "B"],
+            "layer": [0, 1, 0, 1],
+            "attention": [0.9, 0.8, 0.7, 0.6],
+        }
+    )
+    ranks4 = calculate_ranks(df4, "attention", grouping_vars=["model", "layer"])
+    assert ranks4.iloc[0] == 1  # A, 0, 0.9
+    assert ranks4.iloc[1] == 1  # A, 1, 0.8
+    assert ranks4.iloc[2] == 1  # B, 0, 0.7
+    assert ranks4.iloc[3] == 1  # B, 1, 0.6

--- a/src/tests/test_utils_statistics.py
+++ b/src/tests/test_utils_statistics.py
@@ -1,0 +1,164 @@
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.stats import ttest_1samp, wilcoxon
+
+from napistu_torch.utils.constants import (
+    RANK_SHIFT_SUMMARIES,
+    RANK_SHIFT_TESTS,
+    STATISTICAL_TESTS,
+)
+from napistu_torch.utils.statistics import (
+    _compute_rank_shift_for_group,
+    calculate_rank_shift,
+)
+
+
+# Tests for _compute_rank_shift_for_group (private function) - <50 lines
+def test_compute_rank_shift_for_group_basic():
+    """Test _compute_rank_shift_for_group with basic input."""
+    group_df = pd.DataFrame({"rank": [10, 20, 30, 40, 50]})
+    result = _compute_rank_shift_for_group(
+        group_df, "rank", 100, "greater", STATISTICAL_TESTS.WILCOXON_RANKSUM
+    )
+    assert isinstance(result, pd.Series)
+    assert result[RANK_SHIFT_SUMMARIES.MEAN_QUANTILE] == 0.3
+    assert result[RANK_SHIFT_SUMMARIES.MEDIAN_QUANTILE] == 0.3
+    assert (
+        RANK_SHIFT_SUMMARIES.STATISTIC in result
+        and RANK_SHIFT_SUMMARIES.P_VALUE in result
+    )
+    assert 0 <= result[RANK_SHIFT_SUMMARIES.P_VALUE] <= 1
+
+
+def test_compute_rank_shift_for_group_test_methods():
+    """Test _compute_rank_shift_for_group with both test methods."""
+    group_df = pd.DataFrame({"rank": [10, 20, 30, 40, 50]})
+    quantiles = group_df["rank"] / 100
+
+    # Test Wilcoxon
+    result_w = _compute_rank_shift_for_group(
+        group_df, "rank", 100, "greater", STATISTICAL_TESTS.WILCOXON_RANKSUM
+    )
+    expected_stat, expected_p = wilcoxon(quantiles - 0.5, alternative="greater")
+    assert np.isclose(result_w[RANK_SHIFT_SUMMARIES.STATISTIC], expected_stat)
+    assert np.isclose(result_w[RANK_SHIFT_SUMMARIES.P_VALUE], expected_p)
+
+    # Test t-test
+    result_t = _compute_rank_shift_for_group(
+        group_df, "rank", 100, "two-sided", STATISTICAL_TESTS.ONE_SAMPLE_TTEST
+    )
+    expected_stat, expected_p = ttest_1samp(quantiles, 0.5, alternative="two-sided")
+    assert np.isclose(result_t[RANK_SHIFT_SUMMARIES.STATISTIC], expected_stat)
+    assert np.isclose(result_t[RANK_SHIFT_SUMMARIES.P_VALUE], expected_p)
+
+
+def test_compute_rank_shift_for_group_alternatives():
+    """Test _compute_rank_shift_for_group with different alternatives."""
+    # Low ranks = low quantiles
+    result_less = _compute_rank_shift_for_group(
+        pd.DataFrame({"rank": [1, 2, 3, 4, 5]}),
+        "rank",
+        100,
+        "less",
+        STATISTICAL_TESTS.WILCOXON_RANKSUM,
+    )
+    assert result_less[RANK_SHIFT_SUMMARIES.MEAN_QUANTILE] < 0.5
+    assert result_less[RANK_SHIFT_SUMMARIES.P_VALUE] < 0.05
+
+    # High ranks = high quantiles
+    result_greater = _compute_rank_shift_for_group(
+        pd.DataFrame({"rank": [96, 97, 98, 99, 100]}),
+        "rank",
+        100,
+        "greater",
+        STATISTICAL_TESTS.WILCOXON_RANKSUM,
+    )
+    assert result_greater[RANK_SHIFT_SUMMARIES.MEAN_QUANTILE] > 0.5
+    assert result_greater[RANK_SHIFT_SUMMARIES.P_VALUE] < 0.05
+
+
+# Tests for calculate_rank_shift (public function) - <50 lines
+def test_calculate_rank_shift_no_grouping():
+    """Test calculate_rank_shift without grouping."""
+    df = pd.DataFrame({"rank": [10, 20, 30, 40, 50]})
+    result = calculate_rank_shift(df, "rank", 100, grouping_vars=None)
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1
+    expected_cols = [
+        RANK_SHIFT_SUMMARIES.MEAN_QUANTILE,
+        RANK_SHIFT_SUMMARIES.MEDIAN_QUANTILE,
+        RANK_SHIFT_SUMMARIES.MIN_QUANTILE,
+        RANK_SHIFT_SUMMARIES.MAX_QUANTILE,
+        RANK_SHIFT_SUMMARIES.STATISTIC,
+        RANK_SHIFT_SUMMARIES.P_VALUE,
+    ]
+    assert all(col in result.columns for col in expected_cols)
+    assert result[RANK_SHIFT_SUMMARIES.MEAN_QUANTILE].iloc[0] == 0.3
+
+
+def test_calculate_rank_shift_grouping():
+    """Test calculate_rank_shift with single and multiple grouping."""
+    # Single grouping
+    df1 = pd.DataFrame({"layer": [0, 0, 1, 1], "rank": [10, 20, 30, 40]})
+    result1 = calculate_rank_shift(df1, "rank", 100, grouping_vars="layer")
+    assert len(result1) == 2 and "layer" in result1.columns
+    assert set(result1["layer"]) == {0, 1}
+
+    # Multiple grouping
+    df2 = pd.DataFrame(
+        {"model": ["A", "A", "B", "B"], "layer": [0, 1, 0, 1], "rank": [10, 20, 30, 40]}
+    )
+    result2 = calculate_rank_shift(df2, "rank", 100, grouping_vars=["model", "layer"])
+    assert len(result2) == 4
+    assert "model" in result2.columns and "layer" in result2.columns
+
+
+def test_calculate_rank_shift_validation():
+    """Test calculate_rank_shift input validation."""
+    with pytest.raises(ValueError, match="DataFrame must contain 'rank' column"):
+        calculate_rank_shift(pd.DataFrame({"value": [1, 2]}), "rank", 100)
+    with pytest.raises(ValueError, match="Rank values must be less than or equal to"):
+        calculate_rank_shift(pd.DataFrame({"rank": [10, 101]}), "rank", 100)
+    with pytest.raises(
+        ValueError, match="Rank values must be greater than or equal to 1"
+    ):
+        calculate_rank_shift(pd.DataFrame({"rank": [0, 10]}), "rank", 100)
+    with pytest.raises(ValueError, match="DataFrame must contain 'layer' column"):
+        calculate_rank_shift(
+            pd.DataFrame({"rank": [10]}), "rank", 100, grouping_vars="layer"
+        )
+    with pytest.raises(ValueError, match="test_method must be one of"):
+        calculate_rank_shift(
+            pd.DataFrame({"rank": [10]}), "rank", 100, test_method="invalid"
+        )
+    # Verify valid test methods work
+    assert STATISTICAL_TESTS.WILCOXON_RANKSUM in RANK_SHIFT_TESTS
+    assert STATISTICAL_TESTS.ONE_SAMPLE_TTEST in RANK_SHIFT_TESTS
+
+
+def test_calculate_rank_shift_alternatives_and_methods():
+    """Test calculate_rank_shift with different alternatives and test methods."""
+    df = pd.DataFrame({"rank": [10, 20, 30, 40, 50]})
+    result_g = calculate_rank_shift(df, "rank", 100, alternative="greater")
+    result_l = calculate_rank_shift(df, "rank", 100, alternative="less")
+    result_t = calculate_rank_shift(df, "rank", 100, alternative="two-sided")
+    assert (
+        result_g[RANK_SHIFT_SUMMARIES.MEAN_QUANTILE].iloc[0]
+        == result_l[RANK_SHIFT_SUMMARIES.MEAN_QUANTILE].iloc[0]
+    )
+    assert all(
+        RANK_SHIFT_SUMMARIES.P_VALUE in r.columns
+        for r in [result_g, result_l, result_t]
+    )
+
+    result_w = calculate_rank_shift(
+        df, "rank", 100, test_method=STATISTICAL_TESTS.WILCOXON_RANKSUM
+    )
+    result_tt = calculate_rank_shift(
+        df, "rank", 100, test_method=STATISTICAL_TESTS.ONE_SAMPLE_TTEST
+    )
+    assert (
+        result_w[RANK_SHIFT_SUMMARIES.MEAN_QUANTILE].iloc[0]
+        == result_tt[RANK_SHIFT_SUMMARIES.MEAN_QUANTILE].iloc[0]
+    )


### PR DESCRIPTION
- in `foundation_models.py` the "topk" methods now support a compute_ranks which add the rank of the attention value. This is primarily relevant when `reextract`=True because in that case we pull out all of the attentions in each model/layer that were topK in another. These summaries with ranks are sufficient to identify agreement between the topK ranks of 1 models and the distribution of ranks in another. Closes #157
- `utils.statistics` module added to compute conditional ranks of a set of gene x gene attention layers in an eval layer based on the topK values in a query layer. It then calculate a Wilcoxon ranksum based on these. The structure here (input for `calculate_rank_shift`) matches the output of the top_k foundation model methods when compute_ranks = True 
- `tensor_utils.compute_tensor_ranks` and `tensor_utils.compute_tensor_ranks_for_indices` calculate the ranks of a Tensor
