### PR TITLE
Issue 178 - NapistuData validation and reversal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu-torch
-version = 0.3.11
+version = 0.3.12
 description = PyTorch-based toolkit for working with Napistu network graphs
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu_torch/napistu_data.py
+++ b/src/napistu_torch/napistu_data.py
@@ -147,6 +147,8 @@ class NapistuData(Data):
         Trim the NapistuData object to keep only the specified attributes
     unencode_features(napistu_graph, attribute_type, attribute, encoding_manager=None)
         Unencode features from the NapistuData object
+    validate_graph_alignment(napistu_graph)
+        Validate the alignment of the NapistuData object with the NapistuGraph
 
     Private Methods
     ---------------
@@ -1325,6 +1327,136 @@ class NapistuData(Data):
             decoded_values = decoded.flatten()
 
         return pd.Series(decoded_values, name=attribute)
+
+    def validate_graph_alignment(self, napistu_graph: NapistuGraph) -> None:
+        """
+        Validate structural alignment between this NapistuData and a NapistuGraph.
+
+        Checks that vertex and edge counts match, and that the stored ng_vertex_names
+        and ng_edge_names in this NapistuData are consistent with the NapistuGraph's
+        vertex and edge ordering.
+
+        Parameters
+        ----------
+        napistu_graph : NapistuGraph
+            The NapistuGraph this data was built from (or should align with).
+
+        Raises
+        ------
+        ValueError
+            If vertex counts, edge counts, or name orderings don't match.
+        """
+        # Vertex alignment
+        ng_vertex_names = self.get_vertex_names()
+        graph_vertex_df = napistu_graph.get_vertex_dataframe()
+
+        if self.num_nodes != len(graph_vertex_df):
+            raise ValueError(
+                f"Vertex count mismatch: NapistuData has {self.num_nodes} nodes, "
+                f"NapistuGraph has {len(graph_vertex_df)} vertices."
+            )
+
+        if ng_vertex_names is not None:
+            if len(ng_vertex_names) != len(graph_vertex_df):
+                raise ValueError(
+                    f"ng_vertex_names length ({len(ng_vertex_names)}) does not match "
+                    f"NapistuGraph vertex count ({len(graph_vertex_df)})."
+                )
+            graph_names = graph_vertex_df[NAPISTU_GRAPH_VERTICES.NAME].values
+            if not (ng_vertex_names.values == graph_names).all():
+                first_mismatch = next(
+                    i
+                    for i, (a, b) in enumerate(zip(ng_vertex_names.values, graph_names))
+                    if a != b
+                )
+                raise ValueError(
+                    "Vertex name ordering mismatch between NapistuData and NapistuGraph. "
+                    f"First mismatch at index {first_mismatch}: "
+                    f"NapistuData='{ng_vertex_names.iloc[first_mismatch]}', "
+                    f"NapistuGraph='{graph_names[first_mismatch]}'."
+                )
+        else:
+            logger.warning(
+                "ng_vertex_names not present in NapistuData — vertex name alignment "
+                "cannot be verified."
+            )
+
+        # Edge alignment
+        ng_edge_names = self.get_edge_names()
+        graph_edge_df = napistu_graph.get_edge_dataframe()
+
+        if self.num_edges != len(graph_edge_df):
+            raise ValueError(
+                f"Edge count mismatch: NapistuData has {self.num_edges} edges, "
+                f"NapistuGraph has {len(graph_edge_df)} edges."
+            )
+
+        if ng_edge_names is not None:
+            if len(ng_edge_names) != len(graph_edge_df):
+                raise ValueError(
+                    f"ng_edge_names length ({len(ng_edge_names)}) does not match "
+                    f"NapistuGraph edge count ({len(graph_edge_df)})."
+                )
+            from_match = (
+                ng_edge_names[NAPISTU_GRAPH_EDGES.FROM].values
+                == graph_edge_df[NAPISTU_GRAPH_EDGES.FROM].values
+            ).all()
+            to_match = (
+                ng_edge_names[NAPISTU_GRAPH_EDGES.TO].values
+                == graph_edge_df[NAPISTU_GRAPH_EDGES.TO].values
+            ).all()
+            if not (from_match and to_match):
+                raise ValueError(
+                    "Edge (from, to) ordering mismatch between NapistuData and NapistuGraph. "
+                    "Cannot safely assign learned weights or validate features."
+                )
+        else:
+            logger.warning(
+                "ng_edge_names not present in NapistuData — edge name alignment "
+                "cannot be verified."
+            )
+
+    def reverse_edges(self, inplace: bool = True) -> Optional["NapistuData"]:
+        """
+        Reverse all edges by swapping source and target in edge_index.
+
+        Only the edge indices are swapped. Edge attributes (edge_attr) are not
+        modified. If direction-dependent edge attributes need to be swapped as
+        well, reverse the NapistuGraph prior to NapistuData construction.
+
+        Parameters
+        ----------
+        inplace : bool, default=True
+            If True, modify in place. If False, return a new NapistuData.
+
+        Returns
+        -------
+        NapistuData or None
+            If inplace=False, returns a new NapistuData with reversed edges.
+        """
+        logger.warning(
+            "reverse_edges only swaps edge_index (source/target). Edge attributes "
+            "(edge_attr) are not modified. If direction-dependent edge attributes "
+            "need to be swapped, reverse the NapistuGraph prior to NapistuData "
+            "construction."
+        )
+        data = self if inplace else self.clone()
+        data.edge_index = data.edge_index[[1, 0], :]
+
+        # Swap ng_edge_names from/to to stay aligned with edge_index
+        ng_edge_names = getattr(data, NAPISTU_DATA.NG_EDGE_NAMES, None)
+        if (
+            ng_edge_names is not None
+            and NAPISTU_GRAPH_EDGES.FROM in ng_edge_names.columns
+        ):
+            data.ng_edge_names = ng_edge_names.rename(
+                columns={
+                    NAPISTU_GRAPH_EDGES.FROM: "_tmp",
+                    NAPISTU_GRAPH_EDGES.TO: NAPISTU_GRAPH_EDGES.FROM,
+                }
+            ).rename(columns={"_tmp": NAPISTU_GRAPH_EDGES.TO})
+
+        return None if inplace else data
 
     def _validate_vertex_encoding(
         self,

--- a/src/napistu_torch/napistu_data_store.py
+++ b/src/napistu_torch/napistu_data_store.py
@@ -69,7 +69,7 @@ class NapistuDataStore:
     --------------
     create(store_dir, sbml_dfs_path, napistu_graph_path, copy_to_store=False, overwrite=False)
         Create a new NapistuDataStore
-    enable_artifact_creation(sbml_dfs_path, napistu_graph_path)
+    enable_artifact_creation(sbml_dfs_path, napistu_graph_path, copy_to_store=False)
         Convert a read-only store to non-read-only by enabling artifact creation.
     ensure_artifacts(artifact_names, artifact_registry=DEFAULT_ARTIFACT_REGISTRY, overwrite=False)
         Ensure specified artifacts exist in the store, creating if missing.
@@ -77,7 +77,7 @@ class NapistuDataStore:
         Check which artifacts are missing from the store.
     from_config(config)
         Create or load a NapistuDataStore from a DataConfig.
-    from_huggingface(repo_id, store_dir, revision=None, token=None, sbml_dfs_path=None, napistu_graph_path=None)
+    from_huggingface(repo_id, store_dir, revision=None, token=None, sbml_dfs_path=None, napistu_graph_path=None, copy_to_store=False)
         Download and create a NapistuDataStore from HuggingFace Hub.
         Optionally convert from read-only to non-read-only by providing paths.
     list_napistu_datas()
@@ -337,6 +337,7 @@ class NapistuDataStore:
         self,
         sbml_dfs_path: Union[str, Path],
         napistu_graph_path: Union[str, Path],
+        copy_to_store: bool = False,
     ) -> None:
         """
         Convert a read-only store to non-read-only by enabling artifact creation.
@@ -350,6 +351,9 @@ class NapistuDataStore:
             Path to SBML_dfs pickle file
         napistu_graph_path : Union[str, Path]
             Path to NapistuGraph pickle file
+        copy_to_store : bool, default=False
+            If True, copy the files into the store directory and store relative paths.
+            If False, store absolute paths to the original files.
 
         Raises
         ------
@@ -381,16 +385,45 @@ class NapistuDataStore:
             "Converting store from read-only to non-read-only by updating registry..."
         )
 
-        # Resolve paths (handles both absolute and relative paths)
-        resolved_sbml_path = _resolve_path(str(sbml_dfs_path), self.store_dir)
-        resolved_ng_path = _resolve_path(str(napistu_graph_path), self.store_dir)
+        # Resolve paths: user-provided paths are relative to CWD, not store_dir
+        resolved_sbml_path = sbml_dfs_path.resolve()
+        resolved_ng_path = napistu_graph_path.resolve()
+
+        if copy_to_store:
+            napistu_raw_dir = self.store_dir / NAPISTU_DATA_STORE_STRUCTURE.NAPISTU_RAW
+            napistu_raw_dir.mkdir(exist_ok=True)
+
+            cached_sbml_path = napistu_raw_dir / sbml_dfs_path.name
+            cached_ng_path = napistu_raw_dir / napistu_graph_path.name
+
+            logger.info(
+                f"Copying SBML_dfs from {resolved_sbml_path} to {cached_sbml_path}"
+            )
+            logger.info(
+                f"Copying NapistuGraph from {resolved_ng_path} to {cached_ng_path}"
+            )
+
+            shutil.copy2(resolved_sbml_path, cached_sbml_path)
+            shutil.copy2(resolved_ng_path, cached_ng_path)
+
+            sbml_relative = cached_sbml_path.relative_to(self.store_dir)
+            ng_relative = cached_ng_path.relative_to(self.store_dir)
+
+            napistu_entry = {
+                NAPISTU_DATA_STORE.SBML_DFS: str(sbml_relative),
+                NAPISTU_DATA_STORE.NAPISTU_GRAPH: str(ng_relative),
+            }
+            resolved_sbml_path = cached_sbml_path.resolve()
+            resolved_ng_path = cached_ng_path.resolve()
+        else:
+            napistu_entry = {
+                NAPISTU_DATA_STORE.SBML_DFS: str(resolved_sbml_path),
+                NAPISTU_DATA_STORE.NAPISTU_GRAPH: str(resolved_ng_path),
+            }
 
         # Update registry
         self.registry[NAPISTU_DATA_STORE.READ_ONLY] = False
-        self.registry[NAPISTU_DATA_STORE.NAPISTU_RAW] = {
-            NAPISTU_DATA_STORE.SBML_DFS: str(resolved_sbml_path),
-            NAPISTU_DATA_STORE.NAPISTU_GRAPH: str(resolved_ng_path),
-        }
+        self.registry[NAPISTU_DATA_STORE.NAPISTU_RAW] = napistu_entry
 
         # Save updated registry
         self._save_registry()
@@ -738,6 +771,7 @@ class NapistuDataStore:
         token: Optional[str] = None,
         sbml_dfs_path: Optional[Union[str, Path]] = None,
         napistu_graph_path: Optional[Union[str, Path]] = None,
+        copy_to_store: bool = False,
     ) -> "NapistuDataStore":
         """
         Download and create a NapistuDataStore from HuggingFace Hub.
@@ -764,6 +798,10 @@ class NapistuDataStore:
         napistu_graph_path : Optional[Union[str, Path]]
             Path to NapistuGraph pickle file. If provided along with sbml_dfs_path,
             converts the store from read-only to non-read-only.
+        copy_to_store : bool, default=False
+            If True, copy sbml_dfs and napistu_graph into the store directory and
+            store relative paths. If False, store absolute paths to the original files.
+            Only applies when sbml_dfs_path and napistu_graph_path are provided.
 
         Returns
         -------
@@ -796,6 +834,15 @@ class NapistuDataStore:
         ...     napistu_graph_path=Path("/data/graph.pkl")
         ... )
         >>>
+        >>> # Load and copy raw data into store for portability
+        >>> store = NapistuDataStore.from_huggingface(
+        ...     repo_id="username/my-dataset",
+        ...     store_dir=Path("./local_store"),
+        ...     sbml_dfs_path=Path("./.napistu/sbml_dfs.pkl"),
+        ...     napistu_graph_path=Path("./.napistu/graph.pkl"),
+        ...     copy_to_store=True
+        ... )
+        >>>
         >>> # Use the store
         >>> napistu_data = store.load_napistu_data("edge_prediction")
         """
@@ -821,7 +868,9 @@ class NapistuDataStore:
                     "to convert the store from read-only to non-read-only. "
                     "Cannot provide only one."
                 )
-            store.enable_artifact_creation(sbml_dfs_path, napistu_graph_path)
+            store.enable_artifact_creation(
+                sbml_dfs_path, napistu_graph_path, copy_to_store=copy_to_store
+            )
 
         return store
 

--- a/src/tests/test_napistu_data.py
+++ b/src/tests/test_napistu_data.py
@@ -8,13 +8,14 @@ from pathlib import Path
 import pandas as pd
 import pytest
 import torch
-from napistu.constants import IDENTIFIERS
+from napistu.constants import IDENTIFIERS, SBML_DFS
 from napistu.network.constants import (
     NAPISTU_GRAPH,
     NAPISTU_GRAPH_EDGES,
     NAPISTU_GRAPH_NODE_TYPES,
     NAPISTU_GRAPH_VERTICES,
 )
+from napistu.network.ng_core import NapistuGraph
 from napistu.ontologies.constants import ONTOLOGIES
 from utils import assert_tensors_equal
 
@@ -830,3 +831,41 @@ def test_get_symmetrical_relation_indices_failure_cases(edge_masked_napistu_data
     )
     with pytest.raises(ValueError, match="malformed relation names"):
         data_malformed.get_symmetrical_relation_indices()
+
+
+def test_validate_graph_alignment_passes(napistu_data, augmented_napistu_graph):
+    """Validate graph alignment passes when NapistuData was built from the given graph."""
+    napistu_data.validate_graph_alignment(augmented_napistu_graph)
+
+
+def test_validate_graph_alignment_fails_on_wrong_graph(napistu_data):
+    """Validate graph alignment raises when compared to a different (random) graph."""
+    # Build a small graph that does not match napistu_data
+    wrong_graph = NapistuGraph(directed=True)
+    wrong_graph.add_vertex(name="X", node_type=SBML_DFS.SPECIES)
+    wrong_graph.add_vertex(name="Y", node_type=SBML_DFS.SPECIES)
+    wrong_graph.add_vertex(name="Z", node_type=SBML_DFS.SPECIES)
+    wrong_graph.add_edge("X", "Y")
+    wrong_graph.add_edge("Y", "Z")
+
+    with pytest.raises(ValueError, match="Vertex count mismatch"):
+        napistu_data.validate_graph_alignment(wrong_graph)
+
+
+def test_reverse_edges_swaps_edge_index(napistu_data):
+    """reverse_edges swaps source and target in edge_index."""
+    original_src = napistu_data.edge_index[0].clone()
+    original_tgt = napistu_data.edge_index[1].clone()
+    napistu_data.reverse_edges(inplace=True)
+    assert torch.equal(napistu_data.edge_index[0], original_tgt)
+    assert torch.equal(napistu_data.edge_index[1], original_src)
+
+
+def test_reverse_edges_out_of_place_returns_new(napistu_data):
+    """reverse_edges(inplace=False) returns new NapistuData without modifying original."""
+    original_edge_index = napistu_data.edge_index.clone()
+    reversed_data = napistu_data.reverse_edges(inplace=False)
+    assert reversed_data is not napistu_data
+    assert torch.equal(napistu_data.edge_index, original_edge_index)
+    assert torch.equal(reversed_data.edge_index[0], original_edge_index[1])
+    assert torch.equal(reversed_data.edge_index[1], original_edge_index[0])

--- a/src/tests/test_napistu_data_store.py
+++ b/src/tests/test_napistu_data_store.py
@@ -766,3 +766,54 @@ def test_enable_artifact_creation(sbml_dfs, napistu_graph):
         assert reloaded_store.read_only is False
         assert reloaded_store.sbml_dfs_path is not None
         assert reloaded_store.napistu_graph_path is not None
+
+
+@pytest.mark.skip_on_windows
+def test_enable_artifact_creation_copy_to_store(sbml_dfs, napistu_graph):
+    """Test enable_artifact_creation with copy_to_store=True copies files and stores relative paths."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create pickle files outside the store
+        data_dir = Path(temp_dir) / "external_data"
+        data_dir.mkdir()
+        sbml_dfs_path = data_dir / "sbml_dfs.pkl"
+        napistu_graph_path = data_dir / "napistu_graph.pkl"
+        sbml_dfs.to_pickle(sbml_dfs_path)
+        napistu_graph.to_pickle(napistu_graph_path)
+
+        # Create read-only store
+        store_dir = Path(temp_dir) / "store"
+        read_only_store = NapistuDataStore.create(
+            store_dir=store_dir,
+            read_only=True,
+        )
+
+        # Enable artifact creation with copy_to_store
+        read_only_store.enable_artifact_creation(
+            sbml_dfs_path, napistu_graph_path, copy_to_store=True
+        )
+
+        # Verify files were copied into store
+        napistu_raw_dir = store_dir / "napistu_raw"
+        assert (napistu_raw_dir / "sbml_dfs.pkl").exists()
+        assert (napistu_raw_dir / "napistu_graph.pkl").exists()
+
+        # Verify registry has relative paths
+        napistu_raw = read_only_store.registry[NAPISTU_DATA_STORE.NAPISTU_RAW]
+        assert napistu_raw[NAPISTU_DATA_STORE.SBML_DFS] == "napistu_raw/sbml_dfs.pkl"
+        assert (
+            napistu_raw[NAPISTU_DATA_STORE.NAPISTU_GRAPH]
+            == "napistu_raw/napistu_graph.pkl"
+        )
+
+        # Verify we can load (from copied files)
+        loaded_sbml = read_only_store.load_sbml_dfs()
+        loaded_ng = read_only_store.load_napistu_graph()
+        assert loaded_sbml is not None
+        assert loaded_ng is not None
+
+        # Remove original files and verify store still works (uses copies)
+        sbml_dfs_path.unlink()
+        napistu_graph_path.unlink()
+        reloaded_store = NapistuDataStore(store_dir=store_dir)
+        assert reloaded_store.load_sbml_dfs() is not None
+        assert reloaded_store.load_napistu_graph() is not None

--- a/src/tests/test_utils_pd_utils.py
+++ b/src/tests/test_utils_pd_utils.py
@@ -1,3 +1,5 @@
+"""Tests for pandas utility functions."""
+
 import numpy as np
 import pandas as pd
 import pytest


### PR DESCRIPTION
- `napistu_data.NapistuData`
    - added `validate_graph_alignment` for validating the equivalence of a `NapistuData` and `NapistuGraph`. Closes #178 
    - added `reverse` for flipping the from/to indices in an edgelist. This is imperfect because it won't update edge attributes since they would need to be unencoded; swapped (using a procedure like NapistuGraph.reverse) and then re-encoded. Instead it just warns that its probably best to reverse the `NapistuGraph` prior to `NapistuData` construction. But, the method is still useful for inexact work.
- `napistu_data_store.NapistuDataStore` - added support for copying an SBML_dfs & NapistuGraph into a NapistuDataStore when it is initialized from HuggingFace. This improves the user experience.