### PR TITLE
Issue 184 - extract and save layer-wise residual streams for scGPT

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu-torch
-version = 0.3.13
+version = 0.3.14
 description = PyTorch-based toolkit for working with Napistu network graphs
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu_torch/load/constants.py
+++ b/src/napistu_torch/load/constants.py
@@ -243,6 +243,7 @@ FM_DEFS = SimpleNamespace(
     WEIGHTS_DICT="weights_dict",
     STATIC_GENE_EMBEDDINGS="static_gene_embeddings",
     ATTENTION_WEIGHTS="attention_weights",
+    LAYER_IDX="layer_idx",
     LAYER_NAME_TEMPLATE="layer_{layer_idx}",
     W_Q="W_q",
     W_K="W_k",
@@ -286,6 +287,7 @@ FM_DEFAULTS = SimpleNamespace(
 EMBEDDING_METADATA_FIELDS = SimpleNamespace(
     MODEL_NAME=FM_DEFS.MODEL_NAME,
     MODEL_VARIANT=FM_DEFS.MODEL_VARIANT,
+    LAYER_IDX=FM_DEFS.LAYER_IDX,
     DATASET_NAME=FM_DEFS.DATASET_NAME,
     CATEGORY=FM_DEFS.CATEGORY,
     MODEL_LABEL="model_label",
@@ -297,6 +299,7 @@ EMBEDDING_METADATA_FIELDS = SimpleNamespace(
 # are combined into model_label and treated as a single unit.
 SCOPING_FIELDS = [
     EMBEDDING_METADATA_FIELDS.MODEL_LABEL,
+    EMBEDDING_METADATA_FIELDS.LAYER_IDX,
     EMBEDDING_METADATA_FIELDS.DATASET_NAME,
     EMBEDDING_METADATA_FIELDS.CATEGORY,
 ]

--- a/src/napistu_torch/load/foundation_model_etl.py
+++ b/src/napistu_torch/load/foundation_model_etl.py
@@ -700,7 +700,9 @@ def _aidocell_get_expression_embeddings(
     )
 
     expression_embeddings = _expression_tensor_to_gene_embeddings_set(
-        embeddings_3d=cluster_embeddings,
+        embeddings_4d=cluster_embeddings.unsqueeze(
+            1
+        ),  # (n_clusters, 1, n_genes, embed_dim)
         ordered_genes=selected_genes,
         gene_annotations=gene_annotations,
         category_dict=cell_cluster_dict,
@@ -1096,7 +1098,7 @@ def _embed_expression_batch(
 
 
 def _expression_tensor_to_gene_embeddings_set(
-    embeddings_3d: Union[np.ndarray, torch.Tensor],
+    embeddings_4d: Union[np.ndarray, torch.Tensor],
     ordered_genes: List[str],
     gene_annotations: pd.DataFrame,
     category_dict: Dict[int, str],
@@ -1107,30 +1109,23 @@ def _expression_tensor_to_gene_embeddings_set(
     dataset_name: Optional[str] = None,
     dataset_uri: Optional[str] = None,
 ) -> "GeneEmbeddingsSet":
-    """Convert a 3D expression embedding tensor into a GeneEmbeddingsSet.
+    """Convert a 4D expression embedding tensor into a GeneEmbeddingsSet.
 
-    Slices a (n_categories, n_genes, embed_dim) tensor along the category axis
-    and creates one ``GeneEmbeddings`` per category, each with properly filtered
-    and aligned gene annotations. The resulting list is wrapped in a
-    ``GeneEmbeddingsSet`` since all categories within a dataset share the same
-    gene vocabulary.
-
-    Each category becomes a ``GeneEmbeddings`` that owns its full gene metadata,
-    and the set provides dict-like access by source_label.
+    Slices a (n_categories, n_layers, n_genes, embed_dim) tensor along the
+    category and layer axes, creating one ``GeneEmbeddings`` per
+    (category, layer) pair. Each ``GeneEmbeddings`` carries a ``layer_idx``
+    field encoding which residual stream it came from.
 
     Parameters
     ----------
-    embeddings_3d : np.ndarray or torch.Tensor
+    embeddings_4d : np.ndarray or torch.Tensor
         Expression-contextualized gene embeddings of shape
-        (n_categories, n_genes, embed_dim).
+        (n_categories, n_layers, n_genes, embed_dim).
     ordered_genes : List[str]
-        Gene identifiers matching dimension 1 of ``embeddings_3d``.
-        These are looked up in ``gene_annotations[gene_id_column]``
-        to filter and reorder the annotations.
+        Gene identifiers matching dimension 2 of ``embeddings_4d``.
     gene_annotations : pd.DataFrame
-        Full gene annotations table (may contain more genes than
-        ``ordered_genes``). Must contain ``vocab_name`` and ``ensembl_gene``
-        columns at minimum.
+        Full gene annotations table. Must contain ``vocab_name`` and
+        ``ensembl_gene`` columns at minimum.
     category_dict : Dict[int, str]
         Maps category index (0-based) to category name (e.g., cell type).
         Keys must be ``{0, 1, ..., n_categories - 1}``.
@@ -1138,8 +1133,8 @@ def _expression_tensor_to_gene_embeddings_set(
         Column in ``gene_annotations`` to match ``ordered_genes`` against
         (default: 'ensembl_gene').
     align_on : str, optional
-        Column in gene_annotations used for alignment validation in the
-        resulting GeneEmbeddingsSet (default: 'ensembl_gene').
+        Column used for alignment validation in the resulting
+        ``GeneEmbeddingsSet`` (default: 'ensembl_gene').
     model_name : Optional[str]
         Source model name.
     model_variant : Optional[str]
@@ -1152,41 +1147,37 @@ def _expression_tensor_to_gene_embeddings_set(
     Returns
     -------
     GeneEmbeddingsSet
-        Set of GeneEmbeddings, one per category, all sharing the same gene
-        vocabulary. Keyed by ``source_label`` (which encodes
-        model/variant/dataset/category).
+        Set of GeneEmbeddings, one per (category, layer) pair, all sharing
+        the same gene vocabulary. Keyed by ``source_label``.
 
     Raises
     ------
     ValueError
-        If ``embeddings_3d`` is not 3-dimensional.
-        If ``ordered_genes`` length doesn't match dimension 1.
+        If ``embeddings_4d`` is not 4-dimensional.
+        If ``ordered_genes`` length doesn't match dimension 2.
         If ``category_dict`` keys don't match ``{0, ..., n_categories - 1}``.
         If gene annotations cannot be aligned to ``ordered_genes``.
     """
-    # Convert torch to numpy
-    if isinstance(embeddings_3d, torch.Tensor):
-        embeddings_3d = embeddings_3d.numpy()
+    if isinstance(embeddings_4d, torch.Tensor):
+        embeddings_4d = embeddings_4d.numpy()
+    elif not isinstance(embeddings_4d, np.ndarray):
+        raise ValueError("embeddings_4d must be a numpy array or torch.Tensor")
 
-    if not isinstance(embeddings_3d, np.ndarray):
-        raise ValueError("embeddings_3d must be a numpy array or torch.Tensor")
-
-    if embeddings_3d.ndim != 3:
+    if embeddings_4d.ndim != 4:
         raise ValueError(
-            f"embeddings_3d must be 3-dimensional (n_categories, n_genes, embed_dim), "
-            f"got shape {embeddings_3d.shape}"
+            f"embeddings_4d must be 4-dimensional "
+            f"(n_categories, n_layers, n_genes, embed_dim), "
+            f"got shape {embeddings_4d.shape}"
         )
 
-    n_categories, n_genes, _ = embeddings_3d.shape
+    n_categories, n_layers, n_genes, _ = embeddings_4d.shape
 
-    # Validate ordered_genes length
     if len(ordered_genes) != n_genes:
         raise ValueError(
             f"ordered_genes has {len(ordered_genes)} entries but "
-            f"embeddings_3d has {n_genes} genes (dim 1)"
+            f"embeddings_4d has {n_genes} genes (dim 2)"
         )
 
-    # Validate category_dict keys
     category_dict = {int(k): v for k, v in category_dict.items()}
     expected_keys = set(range(n_categories))
     if set(category_dict.keys()) != expected_keys:
@@ -1195,42 +1186,48 @@ def _expression_tensor_to_gene_embeddings_set(
             f"got {sorted(category_dict.keys())}"
         )
 
-    # Filter and reorder gene annotations to match ordered_genes
     aligned_annotations = filter_and_reorder_df(
         df=gene_annotations,
         target_ids=ordered_genes,
         id_column=gene_id_column,
     )
 
-    # Validate that alignment succeeded for all genes
     if len(aligned_annotations) != n_genes:
-        n_found = len(aligned_annotations)
         raise ValueError(
-            f"Only {n_found} of {n_genes} ordered_genes found in "
-            f"gene_annotations['{gene_id_column}']. "
-            f"All genes must be present."
+            f"Only {len(aligned_annotations)} of {n_genes} ordered_genes found in "
+            f"gene_annotations['{gene_id_column}']. All genes must be present."
         )
 
-    # Slice along category axis and create GeneEmbeddings per category
     result = []
     for cat_idx in range(n_categories):
         category_name = category_dict[cat_idx]
+        for layer_idx in range(n_layers):
 
-        ge = GeneEmbeddings(
-            embedding=embeddings_3d[cat_idx],
-            ordered_gene_ids=list(ordered_genes),
-            gene_annotations=aligned_annotations.copy(),
-            model_name=model_name,
-            model_variant=model_variant,
-            dataset_name=dataset_name,
-            dataset_uri=dataset_uri,
-            category=str(category_name),
-        )
-        result.append(ge)
+            logger.debug(
+                f"Creating GeneEmbeddings: cat_idx={cat_idx}, layer_idx={layer_idx}, "
+                f"category={category_name!r}, embedding shape={embeddings_4d[cat_idx, layer_idx].shape}"
+            )
+
+            ge = GeneEmbeddings(
+                embedding=embeddings_4d[cat_idx, layer_idx],
+                ordered_gene_ids=list(ordered_genes),
+                gene_annotations=aligned_annotations.copy(),
+                model_name=model_name,
+                model_variant=model_variant,
+                dataset_name=dataset_name,
+                dataset_uri=dataset_uri,
+                category=str(category_name),
+                layer_idx=layer_idx,
+            )
+            result.append(ge)
+
+            logger.debug(
+                f"  -> ge.layer_idx={ge.layer_idx}, ge.source_label={ge.source_label!r}"
+            )
 
     logger.info(
         f"Created {len(result)} GeneEmbeddings from expression tensor "
-        f"({n_genes} genes, {n_categories} categories)"
+        f"({n_genes} genes, {n_categories} categories, {n_layers} layers)"
     )
 
     return GeneEmbeddingsSet.from_gene_embeddings(result, align_on=align_on)
@@ -1365,7 +1362,7 @@ def _get_cell_clusters_and_category_dict(
     # create unique category labels
     cell_cluster_dict = {
         i: f"{row[CELLXGENE_DEFS.CELL_TYPE]} ({row[CELLXGENE_DEFS.LEIDEN_SCVI]})"
-        for i, row in cell_clusters.iterrows()
+        for i, row in cell_clusters.reset_index(drop=True).iterrows()
     }
     return cell_clusters, cell_cluster_dict
 
@@ -1567,7 +1564,9 @@ def _scfoundation_get_expression_embeddings(
     )
 
     expression_embeddings = _expression_tensor_to_gene_embeddings_set(
-        embeddings_3d=cluster_embeddings,
+        embeddings_4d=cluster_embeddings.unsqueeze(
+            1
+        ),  # (n_clusters, 1, n_genes, embed_dim)
         ordered_genes=selected_genes,
         gene_annotations=gene_annotations,
         category_dict=cell_cluster_dict,
@@ -2036,7 +2035,7 @@ def _scgpt_get_expression_embeddings(
     )
 
     expression_embeddings = _expression_tensor_to_gene_embeddings_set(
-        embeddings_3d=cluster_embeddings,
+        embeddings_4d=cluster_embeddings,  # (n_clusters, n_layers, n_genes, embed_dim)
         ordered_genes=selected_genes,
         gene_annotations=gene_annotations,
         category_dict=cell_cluster_dict,
@@ -2056,92 +2055,51 @@ def _scgpt_get_gene_embedding_by_cell_type(
     device: Optional[Union[torch.device, str]] = None,
     min_cluster_cells: Optional[int] = None,
 ) -> Tuple[torch.Tensor, List[str], Dict[str, str]]:
-    """Get the gene embeddings for each cell type in an AnnData object.
+    """Get layer-wise residual stream embeddings for each cell type.
 
-    Parameters
-    ----------
-    model : scprint.model.model.scPrint
-        The scPRINT model
-    adata : anndata.AnnData
-        The AnnData object containing the cells to embed
-    gene_annotations : List[str]
-        The common genes to use for the embeddings
-    vocab : GeneVocab
-        The vocabulary
-    device : Optional[Union[torch.device, str]]
-        The device to use for the embeddings
-    min_cluster_cells: Optional[int] = None,
-
-    Returns
-    -------
-    Tuple[torch.Tensor, Dict[str, str]]
-        Tuple of (cluster_embeddings, cell_cluster_dict)
-        - cluster_embeddings : torch.Tensor
-            The gene embeddings for each cell type
-        - selected_genes : List[str]
-            The selected genes (ensembl gene ids)
-        - cell_cluster_dict : Dict[str, str]
-            A dictionary mapping cell type indices to cell type names
+    Returns a 4D tensor (n_clusters, n_layers, n_genes, embed_dim) where
+    layer index L is the residual stream entering transformer block L.
     """
-
     device = ensure_device(device, allow_autoselect=True)
 
-    # 1. Get indices into model vocabulary
-    # Get common genes between model and data
-    common_genes_df = gene_annotations.query(
-        f"{ONTOLOGIES.ENSEMBL_GENE} in @adata.var_names"
-    ).assign(index=lambda x: x["vocab_name"].apply(lambda v: vocab[v]))
-    gene_indices = common_genes_df["index"].values
-
-    # 2. Track cell types to setup creating cell-type masks
-    # Use adata.obs here; adata_subset created below has same cells, subset of genes
+    # 1. Track cell types before preprocessing (obs is unchanged by HVG selection)
     cell_clusters, cell_cluster_dict = _get_cell_clusters_and_category_dict(
         adata.obs, min_cluster_cells=min_cluster_cells
     )
 
-    # filter to highly variable genes and bin expression values (as per the training data)
+    # 2. Preprocess: HVG selection, normalization, binning
     adata_subset, selected_genes, gene_indices = _scgpt_preprocess_dataset(
         adata, model, vocab, gene_annotations
     )
 
-    # static embeddings
-    d_gene_indices = gene_indices.to(device)
-    gene_embeddings = model.encoder(d_gene_indices)
-    del d_gene_indices
+    n_clusters = len(cell_clusters)
+    n_layers = len(model.transformer_encoder.layers)
+    n_genes = len(selected_genes)
 
-    # Allocate output
-    cluster_embeddings = torch.zeros(
-        len(cell_clusters),
-        len(selected_genes),
-        model.d_model,
-    )
+    # 4D output: (n_clusters, n_layers, n_genes, embed_dim)
+    cluster_embeddings = torch.zeros(n_clusters, n_layers, n_genes, model.d_model)
 
-    # 3. Embed each cell type
     model.eval()
-    with torch.no_grad():
-        for i, cluster in enumerate(cell_clusters["leiden_scVI"]):
-            cluster_mask = adata_subset.obs["leiden_scVI"] == cluster
-            cluster_adata = adata_subset[cluster_mask]
+    for i, cluster in enumerate(cell_clusters["leiden_scVI"]):
+        cluster_mask = adata_subset.obs["leiden_scVI"] == cluster
+        cluster_adata = adata_subset[cluster_mask]
 
-            logger.info(f"Cluster {i}: {cluster_adata.shape[0]} cells")
+        logger.info(f"Cluster {i}: {cluster_adata.shape[0]} cells")
 
-            if model.input_emb_style == "continuous":
-                cluster_expr = torch.tensor(cluster_adata.X, dtype=torch.float32)
-            else:
-                cluster_expr = torch.tensor(cluster_adata.X)
+        if model.input_emb_style == "continuous":
+            cluster_expr = torch.tensor(cluster_adata.X, dtype=torch.float32)
+        else:
+            cluster_expr = torch.tensor(cluster_adata.X)
 
-            # Use batched processing
-            cluster_embeddings[i] = _embed_expression_batch(
-                model=model,
-                model_type=FOUNDATION_MODEL_NAMES.SCGPT,
-                expression=cluster_expr,
-                gene_emb=gene_embeddings,
-                gene_indices=gene_indices,
-                batch_size=64,
-                device=device,
-            )
+        # Returns (n_layers, n_genes, embed_dim)
+        cluster_embeddings[i] = _scgpt_capture_residual_streams_per_cluster(
+            model=model,
+            expression=cluster_expr,
+            gene_indices=gene_indices,
+            device=device,
+        )
 
-            logger.info(f"  ✓ Completed cluster {i}")
+        logger.info(f"  ✓ Completed cluster {i}")
 
     return cluster_embeddings, selected_genes, cell_cluster_dict
 
@@ -2664,7 +2622,9 @@ def _scprint_get_expression_embeddings(
     )
 
     expression_embeddings = _expression_tensor_to_gene_embeddings_set(
-        embeddings_3d=cluster_embeddings,
+        embeddings_4d=cluster_embeddings.unsqueeze(
+            1
+        ),  # (n_clusters, 1, n_genes, embed_dim),
         ordered_genes=common_genes,
         gene_annotations=gene_annotations,
         category_dict=cell_cluster_dict,

--- a/src/napistu_torch/load/foundation_model_etl.py
+++ b/src/napistu_torch/load/foundation_model_etl.py
@@ -2097,10 +2097,24 @@ def _scgpt_load_model(model_dir: str) -> Tuple[Any, Any, dict, str]:
 
 @require_scgpt
 @require_torchtext
+@require_scgpt
+@require_torchtext
 def _scgpt_load_model_from_file(
     model_file: str, vocab: Any, model_configs: dict
 ) -> Any:
     """Load scGPT model from checkpoint file.
+
+    Handles the naming mismatch between scGPT's fast-transformer attention
+    (stores fused QKV as ``Wqkv``) and stock PyTorch ``nn.MultiheadAttention``
+    (stores fused QKV as ``in_proj``). The two layouts are identical in shape
+    and semantics -- both stack Q, K, V along dim 0 of a single (3*d, d)
+    tensor -- so we remap keys at load time.
+
+    This matters because scGPT checkpoints are saved from the fast-transformer
+    variant, but that variant requires ``flash_attn`` (CUDA-only). On MPS or
+    CPU we must use the vanilla variant. Without remapping, the trained
+    attention weights silently fail to load and every transformer layer runs
+    with random init.
 
     Parameters
     ----------
@@ -2114,13 +2128,13 @@ def _scgpt_load_model_from_file(
     Returns
     -------
     Any
-        Loaded scGPT TransformerModel
+        Loaded scGPT TransformerModel with trained weights
     """
     from scgpt.model import TransformerModel
 
     device = select_device()
 
-    ntokens = len(vocab)  # size of vocabulary
+    ntokens = len(vocab)
     model = TransformerModel(
         ntokens,
         model_configs[SCGPT_DEFS.EMBSIZE],
@@ -2132,28 +2146,45 @@ def _scgpt_load_model_from_file(
         n_input_bins=SCGPT_DEFS.N_INPUT_BINS,
     )
 
-    try:
-        model.load_state_dict(
-            torch.load(model_file, map_location=torch.device(DEVICE.CPU))
+    raw_checkpoint = torch.load(model_file, map_location=torch.device(DEVICE.CPU))
+    remapped_checkpoint = _scgpt_remap_checkpoint_keys(raw_checkpoint)
+
+    model_dict = model.state_dict()
+    compatible = {
+        k: v
+        for k, v in remapped_checkpoint.items()
+        if k in model_dict and v.shape == model_dict[k].shape
+    }
+
+    # Sanity: attention weights must have loaded. Vanilla MultiheadAttention
+    # stores them as in_proj_weight; if none of those matched after remapping,
+    # the model would run with random attention and silently produce garbage.
+    attn_loaded = [k for k in compatible if "self_attn.in_proj_weight" in k]
+    n_expected = model_configs[SCGPT_DEFS.NLAYERS]
+    if len(attn_loaded) != n_expected:
+        raise RuntimeError(
+            f"Expected {n_expected} attention weight tensors to load, "
+            f"but only {len(attn_loaded)} matched. The model would run with "
+            f"untrained attention. Checkpoint keys may use an unexpected "
+            f"layout. Matched attention keys: {attn_loaded}"
         )
-        print(f"Loading all model params from {model_file}")
-    except Exception as e:
-        logger.warning(
-            f"Error loading model: {e}; recovering by extracting specific parameters."
+
+    n_total = len(remapped_checkpoint)
+    n_matched = len(compatible)
+    if n_matched < n_total:
+        skipped = set(remapped_checkpoint) - set(compatible)
+        logger.info(
+            f"Loaded {n_matched}/{n_total} parameters from checkpoint. "
+            f"Skipped {len(skipped)} keys not present in the vanilla model "
+            f"(likely auxiliary heads): {sorted(skipped)[:5]}"
+            f"{'...' if len(skipped) > 5 else ''}"
         )
-        # only load params that are in the model and match the size
-        model_dict = model.state_dict()
-        pretrained_dict = torch.load(model_file, map_location=torch.device(DEVICE.CPU))
-        pretrained_dict = {
-            k: v
-            for k, v in pretrained_dict.items()
-            if k in model_dict and v.shape == model_dict[k].shape
-        }
-        model_dict.update(pretrained_dict)
-        model.load_state_dict(model_dict)
+
+    model_dict.update(compatible)
+    model.load_state_dict(model_dict)
+    logger.info(f"Loaded scGPT weights from {model_file}")
 
     model.to(device)
-
     return model
 
 
@@ -2293,6 +2324,37 @@ def _scgpt_preprocess_dataset(
     )
 
     return adata_subset, selected_genes, gene_indices
+
+
+def _scgpt_remap_checkpoint_keys(checkpoint: dict) -> dict:
+    """Remap scGPT fast-transformer checkpoint keys to vanilla PyTorch names.
+
+    scGPT's fast-transformer attention stores fused Q/K/V projections under
+    ``self_attn.Wqkv.{weight,bias}``. Stock ``nn.MultiheadAttention`` stores
+    the same tensors under ``self_attn.in_proj_{weight,bias}``. Shapes and
+    semantics are identical (Q, K, V stacked along dim 0 of a (3*d, d) tensor).
+
+    Parameters
+    ----------
+    checkpoint : dict
+        Raw state dict loaded from a fast-transformer scGPT checkpoint.
+
+    Returns
+    -------
+    dict
+        State dict with Wqkv keys renamed to in_proj keys. Other keys pass
+        through unchanged.
+    """
+    remapped = {}
+    for key, value in checkpoint.items():
+        if ".Wqkv.weight" in key:
+            new_key = key.replace(".Wqkv.weight", ".in_proj_weight")
+        elif ".Wqkv.bias" in key:
+            new_key = key.replace(".Wqkv.bias", ".in_proj_bias")
+        else:
+            new_key = key
+        remapped[new_key] = value
+    return remapped
 
 
 @require_scprint

--- a/src/napistu_torch/load/foundation_model_etl.py
+++ b/src/napistu_torch/load/foundation_model_etl.py
@@ -1765,20 +1765,24 @@ def _scgpt_capture_residual_streams_per_cluster(
         (n_layers, n_genes, embed_dim), dtype=torch.float32, device=device
     )
 
-    def make_pre_hook(layer_idx):
+    def make_pre_hook(layer_idx, sums: torch.Tensor):
         def hook(module, inputs):
             # inputs is a tuple; first arg is the (batch, n_genes, embed_dim) tensor
-            residual_sums[layer_idx] += inputs[0].sum(dim=0)
+            sums[layer_idx] += inputs[0].sum(dim=0)
+
         return hook
 
-    def make_forward_hook(layer_idx):
+    def make_forward_hook(layer_idx, sums: torch.Tensor):
         def hook(module, inputs, output):
-            residual_sums[layer_idx] += output.sum(dim=0)
+            sums[layer_idx] += output.sum(dim=0)
+
         return hook
 
     handles = []
     handles.append(
-        model.transformer_encoder.register_forward_pre_hook(make_pre_hook(0))
+        model.transformer_encoder.register_forward_pre_hook(
+            make_pre_hook(0, residual_sums)
+        )
     )
     # Block i's output is the residual stream for layer i+1.
     # Skip the final block (i = n_layers - 1) since its output is post-final-block,
@@ -1786,7 +1790,7 @@ def _scgpt_capture_residual_streams_per_cluster(
     for i in range(n_layers - 1):
         handles.append(
             model.transformer_encoder.layers[i].register_forward_hook(
-                make_forward_hook(i + 1)
+                make_forward_hook(i + 1, residual_sums)
             )
         )
 

--- a/src/napistu_torch/load/foundation_model_etl.py
+++ b/src/napistu_torch/load/foundation_model_etl.py
@@ -1709,6 +1709,121 @@ def _scfoundation_preprocess_dataset(
 
 
 @require_scgpt
+def _scgpt_capture_residual_streams_per_cluster(
+    model: "TransformerModel",
+    expression: torch.Tensor,
+    gene_indices: torch.Tensor,
+    batch_size: int = 64,
+    device: Optional[torch.device] = None,
+    verbose: bool = False,
+) -> torch.Tensor:
+    """Capture layer-wise residual streams for a cluster of cells, averaged across cells.
+
+    Runs cells through scGPT's full transformer via ``_encode``, capturing the
+    residual stream entering each of the N attention blocks via forward hooks.
+    Uses pre-layer numbering: residual stream at layer L is the activation
+    block L reads from. For a 12-block scGPT, this returns 12 residual streams
+    (indexed 0 through 11), one per attention block.
+
+    Accumulates running sums across cell batches to stay memory-bounded; the
+    per-cell activations are not retained.
+
+    Parameters
+    ----------
+    model : TransformerModel
+        Loaded scGPT model. Must be in eval mode and on the target device.
+    expression : torch.Tensor
+        Expression matrix (n_cells, n_genes), pre-binned, on CPU or device.
+    gene_indices : torch.Tensor
+        Gene vocabulary indices, shape (n_genes,).
+    batch_size : int, optional
+        Cells per forward pass (default: 64).
+    device : torch.device, optional
+        Device for computation (default: auto-select).
+    verbose : bool, optional
+        Log per-batch progress.
+
+    Returns
+    -------
+    torch.Tensor
+        Residual streams of shape (n_layers, n_genes, embed_dim), averaged
+        across cells. Index L is the activation entering block L.
+    """
+    device = ensure_device(device, allow_autoselect=True)
+
+    t_expression = expression.to(device)
+    t_gene_indices = gene_indices.to(device)
+
+    n_cells, n_genes = t_expression.shape
+    n_layers = len(model.transformer_encoder.layers)
+    embed_dim = model.d_model
+
+    # One running sum per residual stream: (n_genes, embed_dim) per layer.
+    # Layer 0 captures from the pre-hook on transformer_encoder.
+    # Layers 1..N-1 capture from the forward hook on layers[0..N-2].
+    residual_sums = torch.zeros(
+        (n_layers, n_genes, embed_dim), dtype=torch.float32, device=device
+    )
+
+    def make_pre_hook(layer_idx):
+        def hook(module, inputs):
+            # inputs is a tuple; first arg is the (batch, n_genes, embed_dim) tensor
+            residual_sums[layer_idx] += inputs[0].sum(dim=0)
+        return hook
+
+    def make_forward_hook(layer_idx):
+        def hook(module, inputs, output):
+            residual_sums[layer_idx] += output.sum(dim=0)
+        return hook
+
+    handles = []
+    handles.append(
+        model.transformer_encoder.register_forward_pre_hook(make_pre_hook(0))
+    )
+    # Block i's output is the residual stream for layer i+1.
+    # Skip the final block (i = n_layers - 1) since its output is post-final-block,
+    # not a residual stream any attention reads from.
+    for i in range(n_layers - 1):
+        handles.append(
+            model.transformer_encoder.layers[i].register_forward_hook(
+                make_forward_hook(i + 1)
+            )
+        )
+
+    try:
+        with memory_manager(device), torch.no_grad():
+            for start in range(0, n_cells, batch_size):
+                if verbose:
+                    logger.info(
+                        f"  Batch {start // batch_size + 1} of "
+                        f"{(n_cells + batch_size - 1) // batch_size}"
+                    )
+
+                batch_expr = t_expression[start : start + batch_size]
+                bsz = batch_expr.shape[0]
+                src = t_gene_indices.unsqueeze(0).expand(bsz, -1)
+                src_key_padding_mask = torch.zeros(
+                    bsz, n_genes, dtype=torch.bool, device=device
+                )
+
+                # Hooks fire during this call and update residual_sums in place.
+                _ = model._encode(
+                    src, batch_expr, src_key_padding_mask, batch_labels=None
+                )
+
+                del src, src_key_padding_mask
+                empty_cache(device)
+    finally:
+        for h in handles:
+            h.remove()
+
+    residual_means = (residual_sums / n_cells).cpu()
+    del residual_sums, t_expression, t_gene_indices
+
+    return residual_means
+
+
+@require_scgpt
 def _scgpt_extract_attention_weights(
     state_dict: dict, n_layers: int, embed_dim: int
 ) -> List[AttentionLayer]:

--- a/src/napistu_torch/load/foundation_model_etl.py
+++ b/src/napistu_torch/load/foundation_model_etl.py
@@ -1214,10 +1214,10 @@ def _expression_tensor_to_gene_embeddings_set(
                 gene_annotations=aligned_annotations.copy(),
                 model_name=model_name,
                 model_variant=model_variant,
+                layer_idx=layer_idx,
                 dataset_name=dataset_name,
                 dataset_uri=dataset_uri,
                 category=str(category_name),
-                layer_idx=layer_idx,
             )
             result.append(ge)
 

--- a/src/napistu_torch/load/foundation_models.py
+++ b/src/napistu_torch/load/foundation_models.py
@@ -343,7 +343,9 @@ class GeneEmbeddings(BaseModel):
             ),
             model_name=self.model_name,
             model_variant=self.model_variant,
+            layer_idx=self.layer_idx,
             dataset_name=self.dataset_name,
+            dataset_uri=self.dataset_uri,
             category=self.category,
         )
 
@@ -3903,7 +3905,9 @@ def _align_gene_embeddings(
             ),
             model_name=emb.model_name,
             model_variant=emb.model_variant,
+            layer_idx=emb.layer_idx,
             dataset_name=emb.dataset_name,
+            dataset_uri=emb.dataset_uri,
             category=emb.category,
         )
         aligned.append(aligned_emb)
@@ -4581,6 +4585,7 @@ def _gene_embeddings_from_save_dict(
         gene_annotations=pd.DataFrame(ge_annotations),
         model_name=model_name,
         model_variant=model_variant,
+        layer_idx=metadata.get(FM_DEFS.LAYER_IDX),
         dataset_name=metadata.get(FM_DEFS.DATASET_NAME),
         dataset_uri=metadata.get(FM_DEFS.DATASET_URI),
         category=metadata.get(FM_DEFS.CATEGORY),
@@ -4609,6 +4614,7 @@ def _gene_embeddings_to_save_dict(ge: GeneEmbeddings) -> dict:
         FM_DEFS.GENE_ANNOTATIONS: ge.gene_annotations.to_dict("records"),
         FM_DEFS.MODEL_NAME: ge.model_name,
         FM_DEFS.MODEL_VARIANT: ge.model_variant,
+        FM_DEFS.LAYER_IDX: ge.layer_idx,
         FM_DEFS.DATASET_NAME: ge.dataset_name,
         FM_DEFS.DATASET_URI: ge.dataset_uri,
         FM_DEFS.CATEGORY: ge.category,

--- a/src/napistu_torch/load/foundation_models.py
+++ b/src/napistu_torch/load/foundation_models.py
@@ -118,6 +118,10 @@ class GeneEmbeddings(BaseModel):
         Name of the source foundation model (e.g., 'scGPT', 'AIDOCell').
     model_variant : Optional[str]
         Variant of the source model (e.g., 'aido_cell_100m').
+    layer_idx : Optional[int]
+        Index of the transformer layer this embedding represents.
+        None for non-transformer embeddings or models that capture
+        a single activation per category.
     dataset_name : Optional[str]
         Name of the expression dataset used to contextualize embeddings.
         None for static (non-expression-aware) gene embeddings.
@@ -189,6 +193,7 @@ class GeneEmbeddings(BaseModel):
     # Source metadata
     model_name: Optional[str] = None
     model_variant: Optional[str] = None
+    layer_idx: Optional[int] = None
     dataset_name: Optional[str] = None
     dataset_uri: Optional[str] = None
     category: Optional[str] = None
@@ -271,6 +276,8 @@ class GeneEmbeddings(BaseModel):
             if self.model_variant:
                 label = f"{label}_{self.model_variant}"
             parts.append(label)
+        if self.layer_idx is not None:
+            parts.append(f"layer_{self.layer_idx}")
         if self.dataset_name:
             parts.append(self.dataset_name)
         if self.category:
@@ -3932,6 +3939,7 @@ def _build_embedding_metadata(
                 EMBEDDING_METADATA_FIELDS.MODEL_NAME: emb.model_name,
                 EMBEDDING_METADATA_FIELDS.MODEL_VARIANT: emb.model_variant,
                 EMBEDDING_METADATA_FIELDS.MODEL_LABEL: model_label,
+                EMBEDDING_METADATA_FIELDS.LAYER_IDX: emb.layer_idx,
                 EMBEDDING_METADATA_FIELDS.DATASET_NAME: emb.dataset_name,
                 EMBEDDING_METADATA_FIELDS.CATEGORY: emb.category,
             }
@@ -4007,7 +4015,7 @@ def _compute_scoped_keys(
 ) -> Tuple[Dict[str, str], str]:
     """Compute minimal scoped keys and a constant label from embedding metadata.
 
-    For each scoping field (model_label, dataset_name, category):
+    For each scoping field (model_label, dataset_name, category, layer_idx):
     - If the field is constant and non-None across all embeddings, it goes into
       the constant_label and is excluded from keys.
     - If the field varies (or is a mix of None and values), it stays in the keys.
@@ -4018,7 +4026,7 @@ def _compute_scoped_keys(
     ----------
     embedding_metadata : pd.DataFrame
         Output of _build_embedding_metadata. Must contain columns:
-        source_label, model_label, dataset_name, category.
+        source_label, model_label, dataset_name, category, layer_idx.
 
     Returns
     -------
@@ -4043,9 +4051,9 @@ def _compute_scoped_keys(
     >>> # constant_label = ""
     >>> # keys: "scGPT", "scPRINT", "AIDOCell_aido_cell_100m"
 
-    >>> # Different models, same dataset + category
-    >>> # constant_label = "efthymiou2025 / adipocyte (0)"
-    >>> # keys: "scGPT", "scPRINT"
+    >>> # Same model + dataset + category, multiple layers
+    >>> # constant_label = "scGPT / efthymiou2025 / adipocyte (0)"
+    >>> # keys: "layer_0", "layer_5", "layer_11"
     """
     constant_parts = []
     varying_fields = []
@@ -4058,7 +4066,7 @@ def _compute_scoped_keys(
             continue
         elif len(non_null_values) == 1 and embedding_metadata[field].notna().all():
             # Constant non-None across all embeddings
-            constant_parts.append(str(non_null_values[0]))
+            constant_parts.append(_format_scoping_value(field, non_null_values[0]))
         else:
             # Varies across embeddings
             varying_fields.append(field)
@@ -4070,7 +4078,7 @@ def _compute_scoped_keys(
         for field in varying_fields:
             val = row[field]
             if pd.notna(val) and val is not None:
-                key_parts.append(str(val))
+                key_parts.append(_format_scoping_value(field, val))
 
         # Fallback to source_label if no varying fields produce a key
         # (e.g., single embedding where everything is constant)
@@ -4499,6 +4507,30 @@ def _find_top_k_edges_in_attention_layer(
     col_order.append(FM_EDGELIST.ATTENTION)
 
     return df[col_order]
+
+
+def _format_scoping_value(field: str, val: Any) -> str:
+    """Format a scoping field's value for use in scoped keys or constant labels.
+
+    Most fields stringify directly. layer_idx gets a ``"layer_"`` prefix for
+    readability: a key like ``"adipocyte (0)/layer_5"`` is more self-documenting
+    than ``"adipocyte (0)/5"``.
+
+    Parameters
+    ----------
+    field : str
+        Field name from SCOPING_FIELDS.
+    val : Any
+        Non-None field value.
+
+    Returns
+    -------
+    str
+        Formatted string.
+    """
+    if field == EMBEDDING_METADATA_FIELDS.LAYER_IDX:
+        return f"layer_{int(val)}"
+    return str(val)
 
 
 def _gene_embeddings_from_save_dict(

--- a/src/tests/test_load_foundation_models.py
+++ b/src/tests/test_load_foundation_models.py
@@ -19,6 +19,8 @@ from napistu_torch.load.foundation_models import (
     GeneEmbeddings,
     GeneEmbeddingsSet,
     ModelMetadata,
+    _build_embedding_metadata,
+    _compute_scoped_keys,
 )
 
 # ---------------------------------------------------------------------------
@@ -537,6 +539,14 @@ def make_attended_embeddings_set(
 
 # utility functions
 
+# Ensembl IDs shared by scoping tests (same genes; source_labels differ by
+# model/dataset/category/layer).
+SCOPING_TEST_GENES = [
+    "ENSG00000000001",
+    "ENSG00000000002",
+    "ENSG00000000003",
+]
+
 
 def _make_gene_annotations(genes):
     """DataFrame valid for GeneAnnotations (vocab_name + ensembl_gene)."""
@@ -548,7 +558,14 @@ def _make_gene_annotations(genes):
     )
 
 
-def _make_gene_emb(genes, embed_dim=4, model_name=None, category=None):
+def _make_gene_emb(
+    genes,
+    embed_dim=4,
+    model_name=None,
+    dataset_name=None,
+    category=None,
+    layer_idx=None,
+):
     """Minimal GeneEmbeddings for tests."""
     n = len(genes)
     return GeneEmbeddings(
@@ -556,8 +573,19 @@ def _make_gene_emb(genes, embed_dim=4, model_name=None, category=None):
         ordered_gene_ids=list(genes),
         gene_annotations=_make_gene_annotations(genes),
         model_name=model_name,
+        layer_idx=layer_idx,
+        dataset_name=dataset_name,
         category=category,
     )
+
+
+def _scope(embeddings):
+    data = {emb.source_label: emb for emb in embeddings}
+    metadata = _build_embedding_metadata(data)
+    return _compute_scoped_keys(metadata)
+
+
+# tests
 
 
 def test_gene_embeddings_field_validation():
@@ -685,6 +713,17 @@ def test_gene_embeddings_construction():
     assert ge.source_label == "scGPT"
     assert ge.embedding.shape == (3, 8)
 
+    ge = _make_gene_emb(genes, embed_dim=8, model_name="scGPT", layer_idx=0)
+    assert ge.layer_idx == 0
+    assert ge.source_label == "scGPT/layer_0"
+    assert ge.embedding.shape == (3, 8)
+    assert ge.gene_ids_set == frozenset(genes)
+    assert ge.gene_annotations.shape == (3, 2)
+    assert set(ge.gene_annotations.columns) == {
+        FM_DEFS.VOCAB_NAME,
+        ONTOLOGIES.ENSEMBL_GENE,
+    }
+
 
 def test_gene_embeddings_construction_validation():
     """GeneEmbeddings rejects bad embedding shape and row/gene count mismatch."""
@@ -752,9 +791,6 @@ def test_gene_embeddings_align_to_no_overlap_raises():
     assert "No genes in target_ids" in str(e.value)
 
 
-# --- GeneEmbeddingsSet ---
-
-
 def test_gene_embeddings_set_unaligned_vocab_output_aligned_and_gene_dim_matches():
     """From unaligned embeddings with different vocabs, output is aligned and gene dim matches."""
     # Shared ontology: ensembl_gene. Different native vocabs and order/subset per embedding.
@@ -802,9 +838,6 @@ def test_gene_embeddings_set_unaligned_vocab_output_aligned_and_gene_dim_matches
     summary = aligned_set.summary
     assert list(summary["n_genes"]) == [3, 3]
     assert list(summary["key"]) == ["ModelA", "ModelB"]
-
-
-# cross model and layer comparison
 
 
 class TestComputeAttentionReordering:
@@ -993,3 +1026,111 @@ class TestWithDifferentVocabularies:
         assert (
             pivot.isna().sum().sum() == 0
         ), "NaN values found with different vocabulary models"
+
+
+def test_scoping_current_behavior():
+    """Baseline: constant fields fold into label, varying fields go in keys."""
+    # Varying category only
+    scoped, constant = _scope(
+        [
+            _make_gene_emb(
+                SCOPING_TEST_GENES,
+                model_name="scGPT",
+                dataset_name="ds1",
+                category="adipocyte",
+            ),
+            _make_gene_emb(
+                SCOPING_TEST_GENES,
+                model_name="scGPT",
+                dataset_name="ds1",
+                category="T_cell",
+            ),
+        ]
+    )
+    assert set(scoped.values()) == {"adipocyte", "T_cell"}
+    assert constant == "scGPT / ds1"
+
+    # Varying model only
+    scoped, constant = _scope(
+        [
+            _make_gene_emb(SCOPING_TEST_GENES, model_name="scGPT"),
+            _make_gene_emb(SCOPING_TEST_GENES, model_name="scPRINT"),
+        ]
+    )
+    assert set(scoped.values()) == {"scGPT", "scPRINT"}
+    assert constant == ""
+
+    # Two varying fields compose
+    scoped, _ = _scope(
+        [
+            _make_gene_emb(
+                SCOPING_TEST_GENES, model_name="scGPT", category="adipocyte"
+            ),
+            _make_gene_emb(SCOPING_TEST_GENES, model_name="scGPT", category="T_cell"),
+            _make_gene_emb(
+                SCOPING_TEST_GENES, model_name="scPRINT", category="adipocyte"
+            ),
+            _make_gene_emb(SCOPING_TEST_GENES, model_name="scPRINT", category="T_cell"),
+        ]
+    )
+    assert set(scoped.values()) == {
+        "scGPT/adipocyte",
+        "scGPT/T_cell",
+        "scPRINT/adipocyte",
+        "scPRINT/T_cell",
+    }
+
+
+def test_scoping_with_layer_idx():
+    """After adding layer_idx to SCOPING_FIELDS: constant layer folds, varying layer appears in keys."""
+    # Constant layer_idx=0 across all embeddings -> keys unchanged from pre-migration
+    scoped, _ = _scope(
+        [
+            _make_gene_emb(
+                SCOPING_TEST_GENES,
+                model_name="scGPT",
+                dataset_name="ds1",
+                category="adipocyte",
+                layer_idx=0,
+            ),
+            _make_gene_emb(
+                SCOPING_TEST_GENES,
+                model_name="scGPT",
+                dataset_name="ds1",
+                category="T_cell",
+                layer_idx=0,
+            ),
+        ]
+    )
+
+    assert set(scoped.values()) == {"adipocyte", "T_cell"}
+
+    # Varying layer -> layer in keys
+    scoped, constant = _scope(
+        [
+            _make_gene_emb(
+                SCOPING_TEST_GENES,
+                model_name="scGPT",
+                dataset_name="ds1",
+                category="adipocyte",
+                layer_idx=0,
+            ),
+            _make_gene_emb(
+                SCOPING_TEST_GENES,
+                model_name="scGPT",
+                dataset_name="ds1",
+                category="adipocyte",
+                layer_idx=5,
+            ),
+            _make_gene_emb(
+                SCOPING_TEST_GENES,
+                model_name="scGPT",
+                dataset_name="ds1",
+                category="adipocyte",
+                layer_idx=11,
+            ),
+        ]
+    )
+
+    assert len(set(scoped.values())) == 3
+    assert constant == "scGPT / ds1 / adipocyte"


### PR DESCRIPTION
- `GeneEmbeddings` - added `layer_idx` as an optional attribute. This allows per-layer GeneEmbeddings to be easily tracked.
- layer_idx is used when scoping keys to find fixed and variable portions in `_align_gene_embeddings`
- `_expression_tensor_to_gene_embeddings_set` takes a 4D tensor now (category, layer, gene, latent dimension)
- forward pass in scGPT applied in `_scgpt_capture_residual_streams_per_cluster` with forward hooks to extract residual streams
- `_scgpt_load_model_from_file` is patched to rename transformer weights to those expected by `MultiheadAttention` 
- Closes #184 