### PR TITLE
Issue 190 - update attention calculation to use residual streams rather than the layer0 input

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napistu-torch
-version = 0.3.14
+version = 0.3.15
 description = PyTorch-based toolkit for working with Napistu network graphs
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napistu_torch/load/constants.py
+++ b/src/napistu_torch/load/constants.py
@@ -330,7 +330,7 @@ FM_LAYER_CONSENSUS_METHODS = SimpleNamespace(
 VALID_FM_LAYER_CONSENSUS_METHODS = list(FM_LAYER_CONSENSUS_METHODS.__dict__.values())
 
 COMPARE_EMBEDDINGS_COMPARISONS = SimpleNamespace(
-    GENE_EMBEDDING_CORRELATIONS="gene_embedding_correlations",
+    RESIDUAL_STREAM_CORRELATIONS="residual_stream_correlations",
     MODEL_LAYER_CORRELATIONS="model_layer_correlations",
     MODEL_LAYER_RANK_AGREEMENT="model_layer_rank_agreement",
     CROSS_MODEL_X_LAYER_TOP_ATTENTIONS="cross_model_x_layer_top_attentions",

--- a/src/napistu_torch/load/foundation_models.py
+++ b/src/napistu_torch/load/foundation_models.py
@@ -26,6 +26,8 @@ FoundationModels
     Container for one or more foundation models; supports cross-model analysis when len ≥ 2.
 LayerwiseAttentionInputs
     Per-layer residual stream embeddings paired with a foundation model for attention.
+AttentionPatternsInputs
+    Groups ``LayerwiseAttentionInputs`` by model and category for attention-pattern analysis.
 
 Class Relationships
 -------------------
@@ -41,10 +43,10 @@ FoundationModels
                     GeneAnnotations
         ModelMetadata
 
-AttendedEmbeddingsSet
+AttentionPatternsInputs
     LayerwiseAttentionInputs
         Dict[int, GeneEmbeddings] (per-layer residual stream embeddings)
-        FoundationModels (the models containing the attention weights for these embeddings)
+        FoundationModel (per group; supplies attention weights for that group's layers)
 """
 
 import json
@@ -2426,7 +2428,7 @@ class LayerwiseAttentionInputs:
     layer's residual (e.g. static or expression-contextualized activations)
     and references the :class:`FoundationModel` that supplies attention weights.
 
-    Typically created by :class:`AttendedEmbeddingsSet` rather than directly.
+    Typically created by :class:`AttentionPatternsInputs` rather than directly.
 
     Attributes
     ----------
@@ -3005,7 +3007,7 @@ class LayerwiseAttentionInputs:
         )
 
 
-class AttendedEmbeddingsSet:
+class AttentionPatternsInputs:
     """Per-layer residual stream embeddings paired with attention machinery for cross-model analysis.
 
     Takes a :class:`GeneEmbeddingsSet` whose entries are residual-stream
@@ -3059,7 +3061,7 @@ class AttendedEmbeddingsSet:
 
     Public Methods
     --------------
-    from_expression(foundation_models: FoundationModels, dataset_name: str, category: str, align_on: str = ONTOLOGIES.ENSEMBL_GENE, verbose: bool = True) -> "AttendedEmbeddingsSet":
+    from_expression(foundation_models: FoundationModels, dataset_name: str, category: str, align_on: str = ONTOLOGIES.ENSEMBL_GENE, verbose: bool = True) -> "AttentionPatternsInputs":
         Build expression-contextualized per-layer residual streams for a single category.
     get_consensus_attention(k: int = 10000, target_ids: Optional[List[str]] = None, consensus_method: str = FM_LAYER_CONSENSUS_METHODS.ABSOLUTE_ARGMAX, by_absolute_value: bool = True, reextract_union: bool = False, apply_softmax: bool = False, compute_ranks: bool = False, ignore_self_attention: bool = False, return_original_and_reextracted: bool = False, device: Optional[Union[str, torch.device]] = None, verbose: bool = False) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
         Compute consensus attention across all layers for each ``(model × category)`` group.
@@ -3073,12 +3075,12 @@ class AttendedEmbeddingsSet:
     Examples
     --------
     >>> # One (model × category) group per model from expression residual streams
-    >>> attended = AttendedEmbeddingsSet.from_expression(
+    >>> attended = AttentionPatternsInputs.from_expression(
     ...     foundation_models, dataset_name="efthymiou2025", category="adipocyte (0)"
     ... )
 
     >>> # From a pre-built GeneEmbeddingsSet (per-layer residual streams already aligned)
-    >>> attended = AttendedEmbeddingsSet(embeddings_set, foundation_models)
+    >>> attended = AttentionPatternsInputs(embeddings_set, foundation_models)
     """
 
     def __init__(
@@ -3342,8 +3344,8 @@ class AttendedEmbeddingsSet:
         category: str,
         align_on: str = ONTOLOGIES.ENSEMBL_GENE,
         verbose: bool = True,
-    ) -> "AttendedEmbeddingsSet":
-        """Build an :class:`AttendedEmbeddingsSet` from expression-contextualized per-layer residual streams.
+    ) -> "AttentionPatternsInputs":
+        """Build an :class:`AttentionPatternsInputs` from expression-contextualized per-layer residual streams.
 
         For each model, collects per-layer :class:`GeneEmbeddings` for the specified
         dataset and category, aligns them to common genes, and constructs
@@ -3365,7 +3367,7 @@ class AttendedEmbeddingsSet:
 
         Returns
         -------
-        AttendedEmbeddingsSet
+        AttentionPatternsInputs
             Container with one ``(model × category)`` group per model, each holding
             aligned residual streams and attention machinery.
 
@@ -3379,7 +3381,7 @@ class AttendedEmbeddingsSet:
         Examples
         --------
         >>> models = FoundationModels.load_multiple(dir, ['scGPT', 'scPRINT'])
-        >>> attended = AttendedEmbeddingsSet.from_expression(
+        >>> attended = AttentionPatternsInputs.from_expression(
         ...     models, dataset_name="efthymiou2025", category="adipocyte (0)"
         ... )
         >>> attended.n_embeddings
@@ -3844,7 +3846,7 @@ class AttendedEmbeddingsSet:
 
     def __repr__(self) -> str:
         return (
-            f"AttendedEmbeddingsSet("
+            f"AttentionPatternsInputs("
             f"n_embeddings={self.n_embeddings}, "
             f"n_common_genes={self.n_common_genes}, "
             f"models={self.model_names}, "
@@ -3870,7 +3872,7 @@ def aggregate_embedding_comparisons_over_categories(
     Parameters
     ----------
     embedding_comparisons : dict
-        A dictionary of embedding comparison dicts (e.g. from AttendedEmbeddingsSet.compare() per category).
+        A dictionary of embedding comparison dicts (e.g. from AttentionPatternsInputs.compare() per category).
 
     Returns
     -------
@@ -3974,7 +3976,7 @@ def validate_embedding_comparisons_settings(
     Parameters
     ----------
     embedding_comparisons : Dict[str, Any]
-        The comparisons to validate. Created by AttendedEmbeddingsSet.compare().
+        The comparisons to validate. Created by AttentionPatternsInputs.compare().
     top_k : int
         The number of top-k attention pairs to summarize.
     consensus_method : str
@@ -5046,7 +5048,7 @@ def _group_embeddings_by_model_and_category(
         if emb.layer_idx is None:
             raise ValueError(
                 f"Embedding '{key}' has layer_idx=None. "
-                f"AttendedEmbeddingsSet requires per-layer residual streams."
+                f"AttentionPatternsInputs requires per-layer residual streams."
             )
 
         # Verify the embedding's own model_name matches the group it's being

--- a/src/napistu_torch/load/foundation_models.py
+++ b/src/napistu_torch/load/foundation_models.py
@@ -23,7 +23,9 @@ ModelMetadata
 FoundationModel
     Complete foundation model including weights, annotations, and metadata.
 FoundationModels
-    Container for multiple foundation models with cross-model analysis capabilities.
+    Container for one or more foundation models; supports cross-model analysis when len ≥ 2.
+LayerwiseAttentionInputs
+    Per-layer residual stream embeddings paired with a foundation model for attention.
 
 Class Relationships
 -------------------
@@ -40,7 +42,7 @@ FoundationModels
         ModelMetadata
 
 AttendedEmbeddingsSet
-    AttendedEmbeddings
+    LayerwiseAttentionInputs
         Dict[int, GeneEmbeddings] (per-layer residual stream embeddings)
         FoundationModels (the models containing the attention weights for these embeddings)
 """
@@ -2079,15 +2081,15 @@ class FoundationModel(BaseModel):
 
 
 class FoundationModels(BaseModel):
-    """Container for multiple foundation models with cross-model analysis capabilities.
+    """Container for one or more foundation models with cross-model analysis when applicable.
 
-    This class manages multiple FoundationModel instances and provides methods for
-    cross-model comparisons and alignment operations.
+    This class manages ``FoundationModel`` instances and provides methods for
+    comparisons and alignment operations across models (when multiple are present).
 
     Attributes
     ----------
     models : List[FoundationModel]
-        List of foundation model instances (minimum 2 required)
+        Non-empty list of foundation model instances
 
     Properties
     ----------
@@ -2121,8 +2123,8 @@ class FoundationModels(BaseModel):
     def validate_models_list(cls, v):
         if not isinstance(v, list):
             raise ValueError("models must be a list")
-        if len(v) < 2:
-            raise ValueError("At least 2 models are required for cross-model analysis")
+        if len(v) < 1:
+            raise ValueError("models must contain at least one FoundationModel")
         if not all(isinstance(model, FoundationModel) for model in v):
             raise ValueError("All elements must be FoundationModel instances")
         return v
@@ -2417,7 +2419,7 @@ class FoundationModels(BaseModel):
         return f"FoundationModels(models=[{model_full_names_str}])"
 
 
-class AttendedEmbeddings:
+class LayerwiseAttentionInputs:
     """Per-layer residual stream embeddings paired with a model's attention machinery.
 
     Maps each transformer layer index to a :class:`GeneEmbeddings` for that
@@ -2452,7 +2454,7 @@ class AttendedEmbeddings:
 
     Examples
     --------
-    >>> ae = AttendedEmbeddings(residual_stream_embeddings=per_layer, foundation_model=model)
+    >>> ae = LayerwiseAttentionInputs(residual_stream_embeddings=per_layer, foundation_model=model)
     >>> attn = ae.compute_attention(layer_idx=0)
     >>> consensus = ae.compute_consensus_attention()
     """
@@ -2994,7 +2996,7 @@ class AttendedEmbeddings:
     def __repr__(self) -> str:
         layers = sorted(self.residual_stream_embeddings.keys())
         return (
-            f"AttendedEmbeddings("
+            f"LayerwiseAttentionInputs("
             f"model={self.model_name}, "
             f"layers={layers}, "
             f"n_genes={self.n_genes}, "
@@ -3004,60 +3006,65 @@ class AttendedEmbeddings:
 
 
 class AttendedEmbeddingsSet:
-    """Aligned gene embeddings paired with attention machinery for cross-embedding analysis.
+    """Per-layer residual stream embeddings paired with attention machinery for cross-model analysis.
 
-    Bundles a GeneEmbeddingsSet (aligned embeddings from one or more models/datasets)
-    with references to the FoundationModel instances that produced them. This enables
-    computing attention patterns from any embedding using its model's attention weights,
-    and comparing those patterns across embeddings.
+    Takes a :class:`GeneEmbeddingsSet` whose entries are residual-stream
+    :class:`GeneEmbeddings` (one matrix per transformer layer, per model and category),
+    aligned to common genes. Constructor arguments are validated against a
+    :class:`FoundationModels` container; each group is wrapped as a
+    :class:`LayerwiseAttentionInputs` (per-layer dict plus that group's
+    :class:`FoundationModel` for attention weights).
 
-    The key insight is that attention computation requires:
-    1. An embedding matrix (from GeneEmbeddings — could be static or expression-contextualized)
-    2. Attention weight matrices (W_q, W_k, W_v, W_o from AttentionLayer)
-    3. n_heads (from the model metadata)
+    Attention computation needs:
+    1. Residual stream embeddings per layer (here, as ``GeneEmbeddings`` in ``embeddings_set``)
+    2. Attention weight matrices (W_q, W_k, W_v, W_o from :class:`AttentionLayer`)
+    3. ``n_heads`` (from model metadata)
 
-    Items 2 and 3 are always model-level properties, while item 1 varies per embedding.
-    This class manages the mapping from each embedding to its corresponding model.
+    Attention weights and head counts (items 2 and 3) are fixed per foundation model;
+    the per-layer residual streams (item 1) vary by context (e.g. expression category).
+    This class groups per-layer residual streams into ``(model, category)`` units and
+    exposes them keyed by ``"{full_name}/{category}"``.
 
     Parameters
     ----------
     embeddings_set : GeneEmbeddingsSet
-        Aligned gene embeddings. All embeddings must share the same common genes
-        in the same row order.
+        Aligned residual-stream embeddings. All entries must share the same common genes
+        in the same row order; layer indices and model metadata must allow grouping
+        by model and category.
     foundation_models : FoundationModels
-        Container of FoundationModel instances. Each embedding in embeddings_set
-        must map to exactly one model (via model_name + model_variant -> full_name).
+        Container of :class:`FoundationModel` instances. Each embedding in ``embeddings_set``
+        must map to exactly one model (via ``model_name`` + ``model_variant`` → ``full_name``).
 
     Attributes
     ----------
     embeddings_set : GeneEmbeddingsSet
-        The aligned embeddings.
-    foundation_models : FoundationModels
-        The source foundation models (held by reference).
-    common_gene_ids : List[str]
-        Gene IDs shared across all embeddings (delegates to embeddings_set).
-    embedding_to_model_map : Dict[str, str]
-        Mapping from embedding key (source_label) to model full_name.
+        The aligned per-layer embeddings backing this set.
+    attended_embeddings : Dict[str, LayerwiseAttentionInputs]
+        One :class:`LayerwiseAttentionInputs` per ``(model, category)`` group, keyed by
+        ``"{full_name}/{category}"``.
 
     Properties
     ----------
     n_embeddings : int
-        Number of embeddings in the set.
+        Number of ``(model × category)`` groups (length of ``attended_embeddings``),
+        not the count of individual layer tensors.
     n_common_genes : int
-        Number of common genes.
+        Number of common genes (delegates to ``embeddings_set``).
+    common_gene_ids : List[str]
+        Gene IDs shared across all embeddings (delegates to ``embeddings_set``).
     embedding_keys : List[str]
-        Labels for each embedding.
+        Keys for each group (same as ``attended_embeddings`` keys).
     model_names : List[str]
-        Unique model names referenced by embeddings.
+        Unique model names referenced by groups (order preserved).
 
     Public Methods
     --------------
     from_expression(foundation_models: FoundationModels, dataset_name: str, category: str, align_on: str = ONTOLOGIES.ENSEMBL_GENE, verbose: bool = True) -> "AttendedEmbeddingsSet":
-        Create AttendedEmbeddings from expression-contextualized embeddings.
+        Build expression-contextualized per-layer residual streams for a single category.
     get_consensus_attention(k: int = 10000, target_ids: Optional[List[str]] = None, consensus_method: str = FM_LAYER_CONSENSUS_METHODS.ABSOLUTE_ARGMAX, by_absolute_value: bool = True, reextract_union: bool = False, apply_softmax: bool = False, compute_ranks: bool = False, ignore_self_attention: bool = False, return_original_and_reextracted: bool = False, device: Optional[Union[str, torch.device]] = None, verbose: bool = False) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
-        Compute consensus attention across all layers for each embedding.
+        Compute consensus attention across all layers for each ``(model × category)`` group.
     get_consensus_top_attentions(k: int = 10000, target_ids: Optional[List[str]] = None, consensus_method: str = FM_LAYER_CONSENSUS_METHODS.ABSOLUTE_ARGMAX, by_absolute_value: bool = True, reextract_union: bool = False, apply_softmax: bool = False, compute_ranks: bool = False, ignore_self_attention: bool = False, return_original_and_reextracted: bool = False, device: Optional[Union[str, torch.device]] = None, verbose: bool = False) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
-        Extract top-k consensus attention edges across embeddings.
+        Extract top-k consensus attention edges across groups.
     get_specific_attentions(edges: pd.DataFrame, target_ids: Optional[List[str]] = None, apply_softmax: bool = False, compute_ranks: bool = False, by_absolute_value: bool = True, verbose: bool = False) -> pd.DataFrame:
         Extract specific attention edges across layers.
     get_top_attentions(k: int, layer_indices: Optional[List[int]] = None, target_ids: Optional[List[str]] = None, apply_softmax: bool = False, by_absolute_value: bool = True, compute_ranks: bool = False, ignore_self_attention: bool = False, device: Optional[Union[str, torch.device]] = None, verbose: bool = False) -> pd.DataFrame:
@@ -3065,12 +3072,12 @@ class AttendedEmbeddingsSet:
 
     Examples
     --------
-    >>> # From expression-contextualized embeddings
+    >>> # One (model × category) group per model from expression residual streams
     >>> attended = AttendedEmbeddingsSet.from_expression(
     ...     foundation_models, dataset_name="efthymiou2025", category="adipocyte (0)"
     ... )
 
-    >>> # From a pre-built GeneEmbeddingsSet
+    >>> # From a pre-built GeneEmbeddingsSet (per-layer residual streams already aligned)
     >>> attended = AttendedEmbeddingsSet(embeddings_set, foundation_models)
     """
 
@@ -3122,19 +3129,19 @@ class AttendedEmbeddingsSet:
             if len(model.weights.attention_layers) == 0:
                 raise ValueError(
                     f"Model '{model_name}' has no attention layers. "
-                    f"AttendedEmbeddings requires models with attention weights."
+                    f"LayerwiseAttentionInputs requires models with attention weights."
                 )
 
-        # Build AttendedEmbeddings instances
+        # Build LayerwiseAttentionInputs instances
         groups = _group_embeddings_by_model_and_category(
             embeddings_set, embedding_to_model
         )
 
-        attended: Dict[str, AttendedEmbeddings] = {}
+        attended: Dict[str, LayerwiseAttentionInputs] = {}
         for group_key, layer_embeddings in groups.items():
             full_name, category = group_key
             model = foundation_models.get_model(full_name)
-            attended[f"{full_name}/{category}"] = AttendedEmbeddings(
+            attended[f"{full_name}/{category}"] = LayerwiseAttentionInputs(
                 residual_stream_embeddings=layer_embeddings,
                 foundation_model=model,
             )
@@ -3149,7 +3156,7 @@ class AttendedEmbeddingsSet:
 
     @property
     def n_embeddings(self) -> int:
-        """Number of embeddings."""
+        """Number of (model × category) groups in ``attended_embeddings`` (not per-layer count)."""
         return len(self.attended_embeddings)
 
     @property
@@ -3159,12 +3166,12 @@ class AttendedEmbeddingsSet:
 
     @property
     def embedding_keys(self) -> List[str]:
-        """Labels for each embedding (scoped keys)."""
+        """Keys for each ``(model × category)`` group (``attended_embeddings`` keys)."""
         return list(self.attended_embeddings.keys())
 
     @property
     def model_names(self) -> List[str]:
-        """Unique model names referenced by embeddings (preserves order)."""
+        """Unique model names referenced by groups (preserves order)."""
         seen = set()
         result = []
         for ae in self.attended_embeddings.values():
@@ -3336,16 +3343,16 @@ class AttendedEmbeddingsSet:
         align_on: str = ONTOLOGIES.ENSEMBL_GENE,
         verbose: bool = True,
     ) -> "AttendedEmbeddingsSet":
-        """Create AttendedEmbeddings from expression-contextualized embeddings.
+        """Build an :class:`AttendedEmbeddingsSet` from expression-contextualized per-layer residual streams.
 
-        For each model, retrieves the GeneEmbeddings for the specified
-        dataset and category, aligns them to common genes, and wires up
-        the attention references.
+        For each model, collects per-layer :class:`GeneEmbeddings` for the specified
+        dataset and category, aligns them to common genes, and constructs
+        :class:`LayerwiseAttentionInputs` grouped by model and category.
 
         Parameters
         ----------
         foundation_models : FoundationModels
-            Container with 2+ loaded foundation models. Each model must have
+            Container with one or more loaded foundation models. Each model must have
             dataset_gene_embeddings containing the specified dataset and category.
         dataset_name : str
             Name of the expression dataset (e.g., 'efthymiou2025').
@@ -3359,7 +3366,8 @@ class AttendedEmbeddingsSet:
         Returns
         -------
         AttendedEmbeddingsSet
-            Ready for analysis with aligned expression embeddings.
+            Container with one ``(model × category)`` group per model, each holding
+            aligned residual streams and attention machinery.
 
         Raises
         ------
@@ -3823,7 +3831,7 @@ class AttendedEmbeddingsSet:
 
         return model_layer_correlations, model_layer_rank_agreement
 
-    def __getitem__(self, key: str) -> AttendedEmbeddings:
+    def __getitem__(self, key: str) -> LayerwiseAttentionInputs:
         if key not in self.attended_embeddings:
             raise KeyError(
                 f"Embedding '{key}' not found. "

--- a/src/napistu_torch/load/foundation_models.py
+++ b/src/napistu_torch/load/foundation_models.py
@@ -41,7 +41,7 @@ FoundationModels
 
 AttendedEmbeddingsSet
     AttendedEmbeddings
-        GeneEmbeddingsSet (a set of embedding of interest - static, expression-based, etc.)
+        Dict[int, GeneEmbeddings] (per-layer residual stream embeddings)
         FoundationModels (the models containing the attention weights for these embeddings)
 """
 
@@ -2418,27 +2418,25 @@ class FoundationModels(BaseModel):
 
 
 class AttendedEmbeddings:
-    """A single gene embedding matrix paired with its model's attention machinery.
+    """Per-layer residual stream embeddings paired with a model's attention machinery.
 
-    Pairs one GeneEmbeddings instance (static or expression-contextualized)
-    with a reference to the FoundationModel that produced it. This enables
-    computing attention patterns using this specific embedding's vectors
-    with the model's attention weight matrices.
+    Maps each transformer layer index to a :class:`GeneEmbeddings` for that
+    layer's residual (e.g. static or expression-contextualized activations)
+    and references the :class:`FoundationModel` that supplies attention weights.
 
-    Typically created by AttendedEmbeddingsSet rather than directly by users.
+    Typically created by :class:`AttendedEmbeddingsSet` rather than directly.
 
     Attributes
     ----------
-    gene_embeddings : GeneEmbeddings
-        The gene embedding matrix and associated metadata.
+    residual_stream_embeddings : Dict[int, GeneEmbeddings]
+        Residual embedding matrix and metadata per layer index (0 .. n_layers - 1).
     foundation_model : FoundationModel
-        Reference to the source model (for attention layers, n_heads,
-        gene_annotations, ordered_vocabulary).
+        Source model (attention layers, n_heads, vocabulary, etc.).
 
     Properties
     ----------
-    embedding : np.ndarray
-        The embedding matrix (shortcut to gene_embeddings.embedding).
+    ordered_gene_ids : List[str]
+        Gene IDs in row order (same for every layer).
     n_genes : int
         Number of genes.
     embed_dim : int
@@ -2454,31 +2452,58 @@ class AttendedEmbeddings:
 
     Examples
     --------
-    >>> ae = AttendedEmbeddings(gene_embeddings=ge, foundation_model=model)
+    >>> ae = AttendedEmbeddings(residual_stream_embeddings=per_layer, foundation_model=model)
     >>> attn = ae.compute_attention(layer_idx=0)
     >>> consensus = ae.compute_consensus_attention()
     """
 
     def __init__(
         self,
-        gene_embeddings: GeneEmbeddings,
+        residual_stream_embeddings: Dict[int, GeneEmbeddings],
         foundation_model: FoundationModel,
     ):
-        if not isinstance(gene_embeddings, GeneEmbeddings):
+        if not isinstance(residual_stream_embeddings, dict):
             raise TypeError(
-                f"gene_embeddings must be a GeneEmbeddings, "
-                f"got {type(gene_embeddings)}"
+                f"residual_stream_embeddings must be a Dict[int, GeneEmbeddings], "
+                f"got {type(residual_stream_embeddings)}"
             )
+        if not residual_stream_embeddings:
+            raise ValueError("residual_stream_embeddings must not be empty")
+        for layer_idx, ge in residual_stream_embeddings.items():
+            if not isinstance(layer_idx, int):
+                raise TypeError(
+                    f"residual_stream_embeddings keys must be int layer indices, "
+                    f"got {type(layer_idx)}"
+                )
+            if not isinstance(ge, GeneEmbeddings):
+                raise TypeError(
+                    f"residual_stream_embeddings values must be GeneEmbeddings, "
+                    f"got {type(ge)} at layer {layer_idx}"
+                )
         if not isinstance(foundation_model, FoundationModel):
             raise TypeError(
                 f"foundation_model must be a FoundationModel, "
                 f"got {type(foundation_model)}"
             )
 
-        # Validate that the embedding's model matches the foundation model
-        emb_label = _get_model_label(
-            gene_embeddings.model_name, gene_embeddings.model_variant
-        )
+        expected_layers = set(range(foundation_model.n_layers))
+        provided_layers = set(residual_stream_embeddings.keys())
+        if provided_layers != expected_layers:
+            missing = sorted(expected_layers - provided_layers)
+            extra = sorted(provided_layers - expected_layers)
+            msg_parts = []
+            if missing:
+                msg_parts.append(f"missing layers {missing}")
+            if extra:
+                msg_parts.append(f"unexpected layers {extra}")
+            raise ValueError(
+                f"residual_stream_embeddings layers do not match model. "
+                f"{'; '.join(msg_parts)}. "
+                f"Expected {{0..{foundation_model.n_layers - 1}}}."
+            )
+
+        any_ge = next(iter(residual_stream_embeddings.values()))
+        emb_label = _get_model_label(any_ge.model_name, any_ge.model_variant)
         if emb_label != foundation_model.full_name:
             raise ValueError(
                 f"Embedding model label '{emb_label}' does not match "
@@ -2490,30 +2515,27 @@ class AttendedEmbeddings:
                 f"Model '{foundation_model.full_name}' has no attention layers."
             )
 
-        self.gene_embeddings = gene_embeddings
+        self.residual_stream_embeddings = residual_stream_embeddings
         self.foundation_model = foundation_model
 
     # --- Properties (shortcuts) ---
 
     @property
-    def embedding(self) -> np.ndarray:
-        """The embedding matrix."""
-        return self.gene_embeddings.embedding
+    def ordered_gene_ids(self) -> List[str]:
+        return self.residual_stream_embeddings[0].ordered_gene_ids
 
     @property
     def n_genes(self) -> int:
-        """Number of genes."""
-        return self.gene_embeddings.n_genes
+        return self.residual_stream_embeddings[0].n_genes
 
     @property
     def embed_dim(self) -> int:
-        """Embedding dimensionality."""
-        return self.gene_embeddings.embed_dim
+        return self.residual_stream_embeddings[0].embed_dim
 
     @property
     def n_layers(self) -> int:
-        """Number of attention layers."""
-        return self.foundation_model.n_layers
+        """Number of layers present in residual_stream_embeddings."""
+        return len(self.residual_stream_embeddings)
 
     @property
     def n_heads(self) -> int:
@@ -2539,7 +2561,7 @@ class AttendedEmbeddings:
         verbose: bool = False,
     ) -> pd.DataFrame:
 
-        _, gene_ids = self.gene_embeddings.get_gene_mask(target_ids)
+        _, gene_ids = self._get_gene_mask(target_ids)
 
         top_k_attention_edges = self.get_top_attentions(
             k=top_k,
@@ -2619,15 +2641,15 @@ class AttendedEmbeddings:
         ValueError
             If layer_idx is out of range or target_ids contains unknown genes.
         """
-        if layer_idx >= self.n_layers:
+        if layer_idx not in self.residual_stream_embeddings:
             raise ValueError(
-                f"Layer index {layer_idx} out of range "
-                f"(model has {self.n_layers} layers)"
+                f"Layer index {layer_idx} not found in residual_stream_embeddings. "
+                f"Available layers: {sorted(self.residual_stream_embeddings.keys())}"
             )
 
-        gene_mask, gene_ids = self.gene_embeddings.get_gene_mask(target_ids)
+        gene_mask, _ = self._get_gene_mask(target_ids)
 
-        embeddings = self.embedding
+        embeddings = self._embedding_for_layer(layer_idx)
         if gene_mask is not None:
             embeddings = embeddings[gene_mask]
 
@@ -2644,9 +2666,7 @@ class AttendedEmbeddings:
         # Reorder from embedding order to target_ids order if needed
         if target_ids is not None:
             masked_gene_ids = [
-                gid
-                for gid, m in zip(self.gene_embeddings.ordered_gene_ids, gene_mask)
-                if m
+                gid for gid, m in zip(self.ordered_gene_ids, gene_mask) if m
             ]
             masked_id_to_idx = {gid: i for i, gid in enumerate(masked_gene_ids)}
             reorder_indices = [masked_id_to_idx[gid] for gid in target_ids]
@@ -2698,11 +2718,14 @@ class AttendedEmbeddings:
             If return_layer_indices=True, layer indices of shape (n_genes, n_genes).
         """
 
+        n_genes = len(target_ids) if target_ids is not None else self.n_genes
+        layer_indices = sorted(self.residual_stream_embeddings.keys())
+
         all_attention = torch.zeros(
-            (self.n_genes, self.n_genes, self.n_layers), dtype=torch.float32
+            (n_genes, n_genes, self.n_layers), dtype=torch.float32
         )
 
-        for layer_idx in range(self.n_layers):
+        for stack_pos, layer_idx in enumerate(layer_indices):
             attention = self.compute_attention(
                 layer_idx=layer_idx,
                 target_ids=target_ids,
@@ -2710,7 +2733,7 @@ class AttendedEmbeddings:
                 return_tensor=True,
                 device=device,
             )
-            all_attention[:, :, layer_idx] = attention
+            all_attention[:, :, stack_pos] = attention
 
         if consensus_method == FM_LAYER_CONSENSUS_METHODS.ABSOLUTE_ARGMAX:
             return compute_max_abs_over_z(
@@ -2778,7 +2801,7 @@ class AttendedEmbeddings:
         """
         device = ensure_device(device, allow_autoselect=True)
 
-        _, gene_ids = self.gene_embeddings.get_gene_mask(target_ids)
+        _, gene_ids = self._get_gene_mask(target_ids)
 
         # Convert edge list to indices ONCE
         edge_df = _edgelist_to_indices(
@@ -2788,7 +2811,7 @@ class AttendedEmbeddings:
         )
 
         if layer_indices is None:
-            layer_indices = list(range(self.n_layers))
+            layer_indices = sorted(self.residual_stream_embeddings.keys())
         else:
             layer_indices = normalize_and_validate_indices(
                 indices=layer_indices,
@@ -2897,10 +2920,10 @@ class AttendedEmbeddings:
 
         device = ensure_device(device, allow_autoselect=True)
 
-        _, gene_ids = self.gene_embeddings.get_gene_mask(target_ids)
+        _, gene_ids = self._get_gene_mask(target_ids)
 
         if layer_indices is None:
-            layer_indices = list(range(self.n_layers))
+            layer_indices = sorted(self.residual_stream_embeddings.keys())
         else:
             layer_indices = normalize_and_validate_indices(
                 indices=layer_indices,
@@ -2957,16 +2980,25 @@ class AttendedEmbeddings:
 
         return all_edges
 
-    # --- Dunder ---
+    def _embedding_for_layer(self, layer_idx: int) -> np.ndarray:
+        if layer_idx not in self.residual_stream_embeddings:
+            raise ValueError(
+                f"Layer index {layer_idx} not found in residual_stream_embeddings. "
+                f"Available layers: {sorted(self.residual_stream_embeddings.keys())}"
+            )
+        return self.residual_stream_embeddings[layer_idx].embedding
+
+    def _get_gene_mask(self, target_ids=None):
+        return self.residual_stream_embeddings[0].get_gene_mask(target_ids)
 
     def __repr__(self) -> str:
+        layers = sorted(self.residual_stream_embeddings.keys())
         return (
             f"AttendedEmbeddings("
             f"model={self.model_name}, "
-            f"source={self.gene_embeddings.source_label}, "
+            f"layers={layers}, "
             f"n_genes={self.n_genes}, "
-            f"embed_dim={self.embed_dim}, "
-            f"n_layers={self.n_layers}"
+            f"embed_dim={self.embed_dim}"
             f")"
         )
 
@@ -3020,8 +3052,6 @@ class AttendedEmbeddingsSet:
 
     Public Methods
     --------------
-    from_static(foundation_models: FoundationModels, align_on: str = ONTOLOGIES.ENSEMBL_GENE, verbose: bool = True) -> "AttendedEmbeddingsSet":
-        Create AttendedEmbeddings from the static gene embeddings of all models.
     from_expression(foundation_models: FoundationModels, dataset_name: str, category: str, align_on: str = ONTOLOGIES.ENSEMBL_GENE, verbose: bool = True) -> "AttendedEmbeddingsSet":
         Create AttendedEmbeddings from expression-contextualized embeddings.
     get_consensus_attention(k: int = 10000, target_ids: Optional[List[str]] = None, consensus_method: str = FM_LAYER_CONSENSUS_METHODS.ABSOLUTE_ARGMAX, by_absolute_value: bool = True, reextract_union: bool = False, apply_softmax: bool = False, compute_ranks: bool = False, ignore_self_attention: bool = False, return_original_and_reextracted: bool = False, device: Optional[Union[str, torch.device]] = None, verbose: bool = False) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]:
@@ -3035,11 +3065,6 @@ class AttendedEmbeddingsSet:
 
     Examples
     --------
-    >>> # From static embeddings (most common entry point)
-    >>> attended = AttendedEmbeddingsSet.from_static(foundation_models)
-    >>> attended.n_common_genes
-    15234
-
     >>> # From expression-contextualized embeddings
     >>> attended = AttendedEmbeddingsSet.from_expression(
     ...     foundation_models, dataset_name="efthymiou2025", category="adipocyte (0)"
@@ -3101,19 +3126,21 @@ class AttendedEmbeddingsSet:
                 )
 
         # Build AttendedEmbeddings instances
+        groups = _group_embeddings_by_model_and_category(
+            embeddings_set, embedding_to_model
+        )
+
         attended: Dict[str, AttendedEmbeddings] = {}
-        for key in embeddings_set.keys():
-            full_name = embedding_to_model[key]
+        for group_key, layer_embeddings in groups.items():
+            full_name, category = group_key
             model = foundation_models.get_model(full_name)
-            attended[key] = AttendedEmbeddings(
-                gene_embeddings=embeddings_set[key],
+            attended[f"{full_name}/{category}"] = AttendedEmbeddings(
+                residual_stream_embeddings=layer_embeddings,
                 foundation_model=model,
             )
 
         self.embeddings_set = embeddings_set
         self.attended_embeddings = attended
-
-    # --- Properties ---
 
     @property
     def common_gene_ids(self) -> List[str]:
@@ -3178,12 +3205,12 @@ class AttendedEmbeddingsSet:
             COMPARE_EMBEDDINGS_COMPARISONS.GENE_EMBEDDING_CORRELATIONS
             in comparison_types
         ):
-            logger.info("Calculating gene embedding correlations...")
-            comparisons[COMPARE_EMBEDDINGS_COMPARISONS.GENE_EMBEDDING_CORRELATIONS] = (
+            logger.info("Calculating residual stream correlations...")
+            comparisons[COMPARE_EMBEDDINGS_COMPARISONS.RESIDUAL_STREAM_CORRELATIONS] = (
                 self.embeddings_set.compare_embeddings(verbose=verbose)
             )
         else:
-            comparisons[COMPARE_EMBEDDINGS_COMPARISONS.GENE_EMBEDDING_CORRELATIONS] = (
+            comparisons[COMPARE_EMBEDDINGS_COMPARISONS.RESIDUAL_STREAM_CORRELATIONS] = (
                 None
             )
 
@@ -3359,14 +3386,11 @@ class AttendedEmbeddingsSet:
         expression_embeddings: List[GeneEmbeddings] = []
 
         for model in foundation_models.models:
-            # Validate model has expression embeddings
             if model.dataset_gene_embeddings is None:
                 raise ValueError(
                     f"Model '{model.full_name}' has no dataset_gene_embeddings. "
                     f"Cannot extract expression embeddings."
                 )
-
-            # Validate dataset exists
             if dataset_name not in model.dataset_gene_embeddings:
                 raise ValueError(
                     f"Dataset '{dataset_name}' not found in model "
@@ -3375,73 +3399,12 @@ class AttendedEmbeddingsSet:
                 )
 
             ge_set = model.dataset_gene_embeddings[dataset_name]
-
-            if category not in ge_set:
-                raise ValueError(
-                    f"Category '{category}' not found in dataset '{dataset_name}' "
-                    f"for model '{model.full_name}'. "
-                    f"Available categories: {list(ge_set.keys())}"
-                )
-
-            expression_embeddings.append(ge_set[category])
+            expression_embeddings.extend(
+                _get_category_layer_embeddings(ge_set, category, model, dataset_name)
+            )
 
         embeddings_set = GeneEmbeddingsSet.from_gene_embeddings(
             expression_embeddings, align_on=align_on, verbose=verbose
-        )
-
-        return cls(
-            embeddings_set=embeddings_set,
-            foundation_models=foundation_models,
-        )
-
-    @classmethod
-    def from_static(
-        cls,
-        foundation_models: FoundationModels,
-        align_on: str = ONTOLOGIES.ENSEMBL_GENE,
-        verbose: bool = True,
-    ) -> "AttendedEmbeddingsSet":
-        """Create AttendedEmbeddings from the static gene embeddings of all models.
-
-        Extracts each model's static gene embedding, aligns them to common genes,
-        and wires up the attention references. This replicates the current
-        FoundationModels cross-model analysis workflow.
-
-        Parameters
-        ----------
-        foundation_models : FoundationModels
-            Container with 2+ loaded foundation models.
-        align_on : str, optional
-            Ontology column for gene alignment (default: 'ensembl_gene').
-        verbose : bool, optional
-            Extra reporting (default: True)
-
-        Returns
-        -------
-        AttendedEmbeddingsSet
-            Ready for analysis with aligned static embeddings.
-
-        Examples
-        --------
-        >>> models = FoundationModels.load_multiple(dir, ['scGPT', 'scPRINT'])
-        >>> attended = AttendedEmbeddingsSet.from_static(models)
-        >>> attended.n_common_genes
-        15234
-        >>> attended.embedding_keys
-        ['scGPT', 'scPRINT']
-        """
-        if not isinstance(foundation_models, FoundationModels):
-            raise TypeError(
-                f"foundation_models must be a FoundationModels, "
-                f"got {type(foundation_models)}"
-            )
-
-        static_embeddings = [
-            model.weights.static_gene_embeddings for model in foundation_models.models
-        ]
-
-        embeddings_set = GeneEmbeddingsSet.from_gene_embeddings(
-            static_embeddings, align_on=align_on, verbose=verbose
         )
 
         return cls(
@@ -3808,29 +3771,6 @@ class AttendedEmbeddingsSet:
             )
         return all_top_edges
 
-    # --- Dunder ---
-
-    def __getitem__(self, key: str) -> AttendedEmbeddings:
-        if key not in self.attended_embeddings:
-            raise KeyError(
-                f"Embedding '{key}' not found. "
-                f"Available keys: {self.embedding_keys}"
-            )
-        return self.attended_embeddings[key]
-
-    def __len__(self) -> int:
-        return self.n_embeddings
-
-    def __repr__(self) -> str:
-        return (
-            f"AttendedEmbeddingsSet("
-            f"n_embeddings={self.n_embeddings}, "
-            f"n_common_genes={self.n_common_genes}, "
-            f"models={self.model_names}, "
-            f"keys={self.embedding_keys}"
-            f")"
-        )
-
     def get_within_embeddings_layer_comparisons(
         self,
         top_k: int,
@@ -3883,6 +3823,27 @@ class AttendedEmbeddingsSet:
 
         return model_layer_correlations, model_layer_rank_agreement
 
+    def __getitem__(self, key: str) -> AttendedEmbeddings:
+        if key not in self.attended_embeddings:
+            raise KeyError(
+                f"Embedding '{key}' not found. "
+                f"Available keys: {self.embedding_keys}"
+            )
+        return self.attended_embeddings[key]
+
+    def __len__(self) -> int:
+        return self.n_embeddings
+
+    def __repr__(self) -> str:
+        return (
+            f"AttendedEmbeddingsSet("
+            f"n_embeddings={self.n_embeddings}, "
+            f"n_common_genes={self.n_common_genes}, "
+            f"models={self.model_names}, "
+            f"keys={self.embedding_keys}"
+            f")"
+        )
+
 
 # Public functions
 
@@ -3931,15 +3892,15 @@ def aggregate_embedding_comparisons_over_categories(
         return pd.concat(parts, ignore_index=True)
 
     # gene_embedding_correlations: median over categories (structure from first non-None)
-    vals = _non_none(COMPARE_EMBEDDINGS_COMPARISONS.GENE_EMBEDDING_CORRELATIONS)
+    vals = _non_none(COMPARE_EMBEDDINGS_COMPARISONS.RESIDUAL_STREAM_CORRELATIONS)
     if vals:
-        comparisons[COMPARE_EMBEDDINGS_COMPARISONS.GENE_EMBEDDING_CORRELATIONS] = {
+        comparisons[COMPARE_EMBEDDINGS_COMPARISONS.RESIDUAL_STREAM_CORRELATIONS] = {
             key: np.median([cat[key] for cat in vals]) for key in vals[0]
         }
     else:
         logger.debug(
             "Omitting %s: all categories had None",
-            COMPARE_EMBEDDINGS_COMPARISONS.GENE_EMBEDDING_CORRELATIONS,
+            COMPARE_EMBEDDINGS_COMPARISONS.RESIDUAL_STREAM_CORRELATIONS,
         )
 
     # model_layer_correlations: median over categories per model (structure from first non-None)
@@ -4929,6 +4890,60 @@ def _gene_embeddings_to_save_dict(ge: GeneEmbeddings) -> dict:
     }
 
 
+def _get_category_layer_embeddings(
+    ge_set: GeneEmbeddingsSet,
+    category: str,
+    model: FoundationModel,
+    dataset_name: str,
+) -> List[GeneEmbeddings]:
+    """Extract all per-layer residual stream embeddings for one category.
+
+    Parameters
+    ----------
+    ge_set : GeneEmbeddingsSet
+        The full set of embeddings for a dataset (all categories × layers).
+    category : str
+        The category to extract (e.g., 'adipocyte (0)').
+    model : FoundationModel
+        The model these embeddings belong to (used to validate layer coverage).
+    dataset_name : str
+        Dataset name, used only for error messages.
+
+    Returns
+    -------
+    List[GeneEmbeddings]
+        One GeneEmbeddings per layer, ordered by layer_idx.
+
+    Raises
+    ------
+    ValueError
+        If the category is absent or any layer is missing.
+    """
+    category_embeddings = [ge for ge in ge_set.values() if ge.category == category]
+
+    if not category_embeddings:
+        available_categories = sorted(
+            {ge.category for ge in ge_set.values() if ge.category is not None}
+        )
+        raise ValueError(
+            f"Category '{category}' not found in dataset '{dataset_name}' "
+            f"for model '{model.full_name}'. "
+            f"Available categories: {available_categories}"
+        )
+
+    found_layers = {ge.layer_idx for ge in category_embeddings}
+    expected_layers = set(range(model.n_layers))
+    if found_layers != expected_layers:
+        missing = sorted(expected_layers - found_layers)
+        raise ValueError(
+            f"Category '{category}' in dataset '{dataset_name}' "
+            f"for model '{model.full_name}' is missing layers {missing}. "
+            f"Expected layers {{0..{model.n_layers - 1}}}."
+        )
+
+    return sorted(category_embeddings, key=lambda ge: ge.layer_idx)
+
+
 def _get_disk_name(
     model_name: str,
     model_variant: Optional[str] = None,
@@ -4985,6 +5000,63 @@ def _get_model_label(
     if model_variant is not None:
         return f"{model_name} ({model_variant})"
     return model_name
+
+
+def _group_embeddings_by_model_and_category(
+    embeddings_set: GeneEmbeddingsSet,
+    embedding_to_model: Dict[str, str],
+) -> Dict[Tuple[str, str], Dict[int, GeneEmbeddings]]:
+    """Group a flat GeneEmbeddingsSet into per-(model, category) layer dicts.
+
+    Parameters
+    ----------
+    embeddings_set : GeneEmbeddingsSet
+        Flat set of embeddings, one per (model, category, layer) combination.
+    embedding_to_model : Dict[str, str]
+        Mapping from scoped key to model full_name, pre-validated in __init__.
+
+    Returns
+    -------
+    Dict[Tuple[str, str], Dict[int, GeneEmbeddings]]
+        Outer key: (model_full_name, category).
+        Inner key: layer_idx.
+        Inner value: the GeneEmbeddings for that layer.
+
+    Raises
+    ------
+    ValueError
+        If any embedding has layer_idx=None.
+        If the model derived from the group key does not match the embedding's
+        own model_name (indicates a bug in embedding_to_model).
+    """
+    groups: Dict[Tuple[str, str], Dict[int, GeneEmbeddings]] = {}
+
+    for key, emb in embeddings_set.items():
+        full_name = embedding_to_model[key]
+        group_key = (full_name, emb.category)
+
+        if emb.layer_idx is None:
+            raise ValueError(
+                f"Embedding '{key}' has layer_idx=None. "
+                f"AttendedEmbeddingsSet requires per-layer residual streams."
+            )
+
+        # Verify the embedding's own model_name matches the group it's being
+        # assigned to — catches any mismatch between scoped keys and metadata
+        emb_label = _get_model_label(emb.model_name, emb.model_variant)
+        if emb_label != full_name:
+            raise ValueError(
+                f"Embedding '{key}' has model_name '{emb_label}' but "
+                f"embedding_to_model maps it to '{full_name}'. "
+                f"This indicates a bug in the embedding_to_model mapping."
+            )
+
+        if group_key not in groups:
+            groups[group_key] = {}
+
+        groups[group_key][emb.layer_idx] = emb
+
+    return groups
 
 
 def _load_results(

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -409,9 +409,6 @@ def foundation_models_with_dge(foundation_models):
     return FoundationModels(models=models_with_dge)
 
 
-# --- AttendedEmbeddings fixtures ---
-
-
 @pytest.fixture
 def attended_embeddings():
     return make_attended_embeddings(n_genes=10, n_layers=2)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -7,6 +7,13 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from foundation_model_factories import (
+    _clone_fm_with_dge,
+    _make_layer_grid_dge,
+    make_attended_embeddings,
+    make_foundation_model,
+    make_foundation_models,
+)
 from napistu import consensus, indices
 from napistu.network.constants import (
     NAPISTU_GRAPH_VERTICES,
@@ -42,14 +49,6 @@ from napistu_torch.load.napistu_graphs import (
     napistu_graph_to_napistu_data,
 )
 from napistu_torch.load.stratification import create_composite_edge_strata
-
-from .foundation_model_factories import (
-    _clone_fm_with_dge,
-    _make_layer_grid_dge,
-    make_attended_embeddings,
-    make_foundation_model,
-    make_foundation_models,
-)
 
 # Suppress napistu logging during tests to reduce noise
 logging.getLogger("napistu").setLevel(logging.ERROR)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -39,7 +39,7 @@ from napistu_torch.load.constants import (
     STRATIFY_BY,
 )
 from napistu_torch.load.foundation_models import (
-    AttendedEmbeddingsSet,
+    AttentionPatternsInputs,
     FoundationModels,
 )
 from napistu_torch.load.napistu_graphs import (
@@ -416,7 +416,7 @@ def attended_embeddings():
 
 @pytest.fixture
 def attended_embeddings_set(foundation_models_with_dge):
-    return AttendedEmbeddingsSet.from_expression(
+    return AttentionPatternsInputs.from_expression(
         foundation_models_with_dge,
         dataset_name="ds1",
         category="cluster_0",

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -13,6 +13,7 @@ from napistu.network.constants import (
     NAPISTU_WEIGHTING_STRATEGIES,
 )
 from napistu.network.net_create import process_napistu_graph
+from napistu.ontologies.constants import ONTOLOGIES
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
 from napistu_torch.configs import (
@@ -30,6 +31,10 @@ from napistu_torch.load.constants import (
     SPLITTING_STRATEGIES,
     STRATIFY_BY,
 )
+from napistu_torch.load.foundation_models import (
+    AttendedEmbeddingsSet,
+    FoundationModels,
+)
 from napistu_torch.load.napistu_graphs import (
     augment_napistu_graph,
     construct_unlabeled_napistu_data,
@@ -37,6 +42,14 @@ from napistu_torch.load.napistu_graphs import (
     napistu_graph_to_napistu_data,
 )
 from napistu_torch.load.stratification import create_composite_edge_strata
+
+from .foundation_model_factories import (
+    _clone_fm_with_dge,
+    _make_layer_grid_dge,
+    make_attended_embeddings,
+    make_foundation_model,
+    make_foundation_models,
+)
 
 # Suppress napistu logging during tests to reduce noise
 logging.getLogger("napistu").setLevel(logging.ERROR)
@@ -364,3 +377,52 @@ def experiment_dict(temp_data_config_with_store):
     experiment_dict = prepare_experiment(experiment_config)
 
     return experiment_dict
+
+
+# --- FoundationModel fixtures ---
+
+
+@pytest.fixture
+def foundation_model():
+    return make_foundation_model()
+
+
+@pytest.fixture
+def foundation_models():
+    fm, _ = make_foundation_models(n_models=3, n_shared=15)
+    return fm
+
+
+@pytest.fixture
+def foundation_models_with_dge(foundation_models):
+    models_with_dge = []
+    for model in foundation_models.models:
+        gene_ids = model.gene_annotations[ONTOLOGIES.ENSEMBL_GENE].tolist()
+        dge = _make_layer_grid_dge(
+            n_layers=model.n_layers,
+            n_categories=2,
+            gene_ids=gene_ids,
+            embed_dim=model.embed_dim,
+            model_name=model.model_name,
+            model_variant=model.model_variant,
+        )
+        models_with_dge.append(_clone_fm_with_dge(model, dge))
+    return FoundationModels(models=models_with_dge)
+
+
+# --- AttendedEmbeddings fixtures ---
+
+
+@pytest.fixture
+def attended_embeddings():
+    return make_attended_embeddings(n_genes=10, n_layers=2)
+
+
+@pytest.fixture
+def attended_embeddings_set(foundation_models_with_dge):
+    return AttendedEmbeddingsSet.from_expression(
+        foundation_models_with_dge,
+        dataset_name="ds1",
+        category="cluster_0",
+        verbose=False,
+    )

--- a/src/tests/foundation_model_factories.py
+++ b/src/tests/foundation_model_factories.py
@@ -8,7 +8,6 @@ from napistu.ontologies.constants import ONTOLOGIES
 
 from napistu_torch.load.constants import FM_DEFS
 from napistu_torch.load.foundation_models import (
-    AttendedEmbeddings,
     AttendedEmbeddingsSet,
     AttentionLayer,
     DatasetGeneEmbeddings,
@@ -17,6 +16,7 @@ from napistu_torch.load.foundation_models import (
     FoundationModelWeights,
     GeneEmbeddings,
     GeneEmbeddingsSet,
+    LayerwiseAttentionInputs,
     ModelMetadata,
 )
 
@@ -94,9 +94,9 @@ def _make_layer_grid_dge(
     n_layers: int,
     n_categories: int,
     gene_ids: List[str],
+    model_name: str,
     embed_dim: int = 8,
     layers_per_emb: Optional[List[int]] = None,
-    model_name: str = "TestModel",
     model_variant: Optional[str] = None,
     dataset_name: str = "ds1",
     gene_annotations: Optional[pd.DataFrame] = None,
@@ -347,7 +347,7 @@ def make_foundation_models(
 
 
 # ---------------------------------------------------------------------------
-# AttendedEmbeddings factories  (depend on FoundationModel factories)
+# LayerwiseAttentionInputs factories  (depend on FoundationModel factories)
 # ---------------------------------------------------------------------------
 
 
@@ -360,7 +360,7 @@ def make_attended_embeddings(
     category: str = "cluster_0",
     dataset_name: str = "ds1",
     seed: int = 42,
-) -> AttendedEmbeddings:
+) -> LayerwiseAttentionInputs:
     gene_ids = make_gene_ids(n_genes)
     model = make_foundation_model(
         n_genes=n_genes,
@@ -384,7 +384,7 @@ def make_attended_embeddings(
     residual_map = {
         ge.layer_idx: ge for ge in ge_set.values() if ge.category == category
     }
-    return AttendedEmbeddings(
+    return LayerwiseAttentionInputs(
         residual_stream_embeddings=residual_map,
         foundation_model=model,
     )

--- a/src/tests/foundation_model_factories.py
+++ b/src/tests/foundation_model_factories.py
@@ -1,0 +1,431 @@
+"""Shared factories and utilities for foundation model tests."""
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from napistu.ontologies.constants import ONTOLOGIES
+
+from napistu_torch.load.constants import FM_DEFS
+from napistu_torch.load.foundation_models import (
+    AttendedEmbeddings,
+    AttendedEmbeddingsSet,
+    AttentionLayer,
+    DatasetGeneEmbeddings,
+    FoundationModel,
+    FoundationModels,
+    FoundationModelWeights,
+    GeneEmbeddings,
+    GeneEmbeddingsSet,
+    ModelMetadata,
+)
+
+# ---------------------------------------------------------------------------
+# Primitive utilities  (no dependencies on other factories)
+# ---------------------------------------------------------------------------
+
+SCOPING_TEST_GENES = [
+    "ENSG00000000001",
+    "ENSG00000000002",
+    "ENSG00000000003",
+]
+
+
+def make_gene_ids(n: int, prefix: str = "ENSG", start: int = 0) -> List[str]:
+    return [f"{prefix}{str(i).zfill(5)}" for i in range(start, start + n)]
+
+
+def make_gene_annotations(
+    gene_ids: List[str],
+    vocab_names: Optional[List[str]] = None,
+    symbols: Optional[List[str]] = None,
+) -> pd.DataFrame:
+    if vocab_names is None:
+        vocab_names = list(gene_ids)
+    if symbols is None:
+        symbols = [f"SYM_{str(i).zfill(5)}" for i in range(len(gene_ids))]
+    return pd.DataFrame(
+        {
+            FM_DEFS.VOCAB_NAME: vocab_names,
+            ONTOLOGIES.ENSEMBL_GENE: gene_ids,
+            "symbol": symbols,
+        }
+    )
+
+
+def _make_gene_annotations(genes: List[str]) -> pd.DataFrame:
+    """Minimal annotations for scoping tests (vocab_name + ensembl_gene only)."""
+    return pd.DataFrame(
+        {
+            FM_DEFS.VOCAB_NAME: list(genes),
+            ONTOLOGIES.ENSEMBL_GENE: list(genes),
+        }
+    )
+
+
+def _make_gene_emb(
+    genes: List[str],
+    embed_dim: int = 4,
+    model_name: Optional[str] = None,
+    dataset_name: Optional[str] = None,
+    category: Optional[str] = None,
+    layer_idx: Optional[int] = None,
+) -> GeneEmbeddings:
+    """Minimal GeneEmbeddings for scoping and unit tests."""
+    n = len(genes)
+    return GeneEmbeddings(
+        embedding=np.arange(n * embed_dim, dtype=np.float64).reshape(n, embed_dim),
+        ordered_gene_ids=list(genes),
+        gene_annotations=_make_gene_annotations(genes),
+        model_name=model_name,
+        layer_idx=layer_idx,
+        dataset_name=dataset_name,
+        category=category,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DGE utilities  (depend only on primitives above)
+# ---------------------------------------------------------------------------
+
+
+def _make_layer_grid_dge(
+    *,
+    n_layers: int,
+    n_categories: int,
+    gene_ids: List[str],
+    embed_dim: int = 8,
+    layers_per_emb: Optional[List[int]] = None,
+    model_name: str = "TestModel",
+    model_variant: Optional[str] = None,
+    dataset_name: str = "ds1",
+    gene_annotations: Optional[pd.DataFrame] = None,
+) -> DatasetGeneEmbeddings:
+    """Expression embeddings: one matrix per (category, layer) pair."""
+    annotations = (
+        gene_annotations
+        if gene_annotations is not None
+        else make_gene_annotations(gene_ids)
+    )
+    rng = np.random.default_rng(42)
+    mats: List[GeneEmbeddings] = []
+    layers_cycle = (
+        layers_per_emb if layers_per_emb is not None else list(range(n_layers))
+    )
+
+    for ci in range(n_categories):
+        for layer in layers_cycle:
+            emb_mx = rng.standard_normal((len(gene_ids), embed_dim)).astype(np.float32)
+            mats.append(
+                GeneEmbeddings(
+                    embedding=emb_mx,
+                    ordered_gene_ids=annotations[FM_DEFS.VOCAB_NAME].tolist(),
+                    gene_annotations=annotations,
+                    model_name=model_name,
+                    model_variant=model_variant,
+                    layer_idx=layer,
+                    dataset_name=dataset_name,
+                    category=f"cluster_{ci}",
+                )
+            )
+
+    ges = GeneEmbeddingsSet.from_gene_embeddings(mats)
+    return DatasetGeneEmbeddings({dataset_name: ges})
+
+
+def _make_all_layer_idx_none_dge(
+    *,
+    gene_ids: List[str],
+    n_embeddings: int = 2,
+    embed_dim: int = 8,
+    dataset_key: str = "ds1",
+) -> DatasetGeneEmbeddings:
+    """Legacy-style embeddings with layer_idx=None (for validation failure tests)."""
+    annotations = make_gene_annotations(gene_ids)
+    rng = np.random.default_rng(0)
+    mats: List[GeneEmbeddings] = []
+    for i in range(n_embeddings):
+        emb_mx = rng.standard_normal((len(gene_ids), embed_dim)).astype(np.float32)
+        mats.append(
+            GeneEmbeddings(
+                embedding=emb_mx,
+                ordered_gene_ids=list(gene_ids),
+                gene_annotations=annotations,
+                model_name="TestModel",
+                layer_idx=None,
+                dataset_name=dataset_key,
+                category=f"cluster_{i}",
+            )
+        )
+    ges = GeneEmbeddingsSet.from_gene_embeddings(mats)
+    return DatasetGeneEmbeddings({dataset_key: ges})
+
+
+def _metadata_dict_from_model(fm: FoundationModel) -> dict:
+    return {
+        FM_DEFS.MODEL_NAME: fm.model_name,
+        FM_DEFS.MODEL_VARIANT: fm.model_variant,
+        FM_DEFS.N_GENES: fm.n_genes,
+        FM_DEFS.N_VOCAB: fm.n_vocab,
+        FM_DEFS.ORDERED_VOCABULARY: fm.ordered_vocabulary,
+        FM_DEFS.EMBED_DIM: fm.embed_dim,
+        FM_DEFS.N_LAYERS: fm.n_layers,
+        FM_DEFS.N_HEADS: fm.n_heads,
+    }
+
+
+def _clone_fm_with_dge(
+    fm: FoundationModel, dge: DatasetGeneEmbeddings
+) -> FoundationModel:
+    return FoundationModel(
+        weights=fm.weights,
+        gene_annotations=fm.gene_annotations,
+        model_metadata=_metadata_dict_from_model(fm),
+        dataset_gene_embeddings=dge,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FoundationModel factories  (depend on DGE utilities)
+# ---------------------------------------------------------------------------
+
+
+def make_attention_layer(
+    embed_dim: int = 16,
+    layer_idx: int = 0,
+    seed: int = 42,
+) -> AttentionLayer:
+    rng = np.random.default_rng(seed)
+    scale = 1.0 / np.sqrt(embed_dim)
+    return AttentionLayer(
+        layer_idx=layer_idx,
+        W_q=rng.standard_normal((embed_dim, embed_dim)).astype(np.float32) * scale,
+        W_k=rng.standard_normal((embed_dim, embed_dim)).astype(np.float32) * scale,
+        W_v=rng.standard_normal((embed_dim, embed_dim)).astype(np.float32) * scale,
+        W_o=rng.standard_normal((embed_dim, embed_dim)).astype(np.float32) * scale,
+    )
+
+
+def make_foundation_model(
+    n_genes: int = 20,
+    embed_dim: int = 16,
+    n_layers: int = 2,
+    n_heads: int = 2,
+    model_name: str = "TestModel",
+    model_variant: Optional[str] = None,
+    gene_ids: Optional[List[str]] = None,
+    vocab_names: Optional[List[str]] = None,
+    extra_vocab: int = 2,
+    seed: int = 42,
+) -> FoundationModel:
+    rng = np.random.default_rng(seed)
+
+    if gene_ids is None:
+        gene_ids = make_gene_ids(n_genes)
+    else:
+        n_genes = len(gene_ids)
+
+    if vocab_names is None:
+        vocab_names = list(gene_ids)
+
+    special_tokens = [f"<special_{i}>" for i in range(extra_vocab)]
+    full_vocab = vocab_names + special_tokens
+    n_vocab = len(full_vocab)
+
+    annotations = make_gene_annotations(gene_ids=gene_ids, vocab_names=vocab_names)
+    full_embedding = rng.standard_normal((n_vocab, embed_dim)).astype(np.float32)
+
+    static_ge = GeneEmbeddings(
+        embedding=full_embedding[:n_genes],
+        ordered_gene_ids=vocab_names,
+        gene_annotations=annotations,
+        model_name=model_name,
+        model_variant=model_variant,
+    )
+
+    attention_layers = [
+        make_attention_layer(embed_dim=embed_dim, layer_idx=i, seed=seed + i + 1)
+        for i in range(n_layers)
+    ]
+
+    weights = FoundationModelWeights(
+        static_gene_embeddings=static_ge,
+        attention_layers=attention_layers,
+    )
+
+    metadata = ModelMetadata(
+        model_name=model_name,
+        model_variant=model_variant,
+        n_genes=n_genes,
+        n_vocab=n_vocab,
+        ordered_vocabulary=full_vocab,
+        embed_dim=embed_dim,
+        n_layers=n_layers,
+        n_heads=n_heads,
+    )
+
+    return FoundationModel(
+        weights=weights,
+        gene_annotations=annotations,
+        model_metadata=metadata,
+    )
+
+
+def make_foundation_model_pair(
+    n_shared: int = 15,
+    n_unique_a: int = 5,
+    n_unique_b: int = 5,
+    embed_dim: int = 16,
+    n_layers_a: int = 2,
+    n_layers_b: int = 2,
+    n_heads: int = 2,
+    model_name_a: str = "ModelA",
+    model_name_b: str = "ModelB",
+    use_different_vocab: bool = False,
+    seed: int = 42,
+) -> Tuple[FoundationModel, FoundationModel, List[str]]:
+    shared_ids = make_gene_ids(n_shared, prefix="ENSG", start=0)
+    unique_a_ids = make_gene_ids(n_unique_a, prefix="ENSG", start=n_shared)
+    unique_b_ids = make_gene_ids(n_unique_b, prefix="ENSG", start=n_shared + n_unique_a)
+
+    gene_ids_a = unique_a_ids + shared_ids
+    gene_ids_b = shared_ids + unique_b_ids
+
+    vocab_names_b = None
+    if use_different_vocab:
+        vocab_names_b = [f"SYM_{str(i).zfill(5)}" for i in range(len(gene_ids_b))]
+
+    model_a = make_foundation_model(
+        gene_ids=gene_ids_a,
+        embed_dim=embed_dim,
+        n_layers=n_layers_a,
+        n_heads=n_heads,
+        model_name=model_name_a,
+        seed=seed,
+    )
+    model_b = make_foundation_model(
+        gene_ids=gene_ids_b,
+        vocab_names=vocab_names_b,
+        embed_dim=embed_dim,
+        n_layers=n_layers_b,
+        n_heads=n_heads,
+        model_name=model_name_b,
+        seed=seed + 1000,
+    )
+
+    return model_a, model_b, shared_ids
+
+
+def make_foundation_models(
+    n_models: int = 3,
+    n_shared: int = 15,
+    n_unique_per_model: int = 5,
+    embed_dim: int = 16,
+    n_layers: int = 2,
+    n_heads: int = 2,
+    seed: int = 42,
+) -> Tuple[FoundationModels, List[str]]:
+    shared_ids = make_gene_ids(n_shared, prefix="ENSG", start=0)
+    models = []
+    for i in range(n_models):
+        unique_start = n_shared + i * n_unique_per_model
+        unique_ids = make_gene_ids(
+            n_unique_per_model, prefix="ENSG", start=unique_start
+        )
+        gene_ids = unique_ids + shared_ids
+        models.append(
+            make_foundation_model(
+                gene_ids=gene_ids,
+                embed_dim=embed_dim,
+                n_layers=n_layers,
+                n_heads=n_heads,
+                model_name=f"TestModel{i}",
+                seed=seed + i * 1000,
+            )
+        )
+    return FoundationModels(models=models), shared_ids
+
+
+# ---------------------------------------------------------------------------
+# AttendedEmbeddings factories  (depend on FoundationModel factories)
+# ---------------------------------------------------------------------------
+
+
+def make_attended_embeddings(
+    n_genes: int = 10,
+    embed_dim: int = 16,
+    n_layers: int = 2,
+    n_heads: int = 2,
+    model_name: str = "TestModel",
+    category: str = "cluster_0",
+    dataset_name: str = "ds1",
+    seed: int = 42,
+) -> AttendedEmbeddings:
+    gene_ids = make_gene_ids(n_genes)
+    model = make_foundation_model(
+        n_genes=n_genes,
+        embed_dim=embed_dim,
+        n_layers=n_layers,
+        n_heads=n_heads,
+        model_name=model_name,
+        gene_ids=gene_ids,
+        seed=seed,
+    )
+    dge = _make_layer_grid_dge(
+        n_layers=n_layers,
+        n_categories=1,
+        gene_ids=gene_ids,
+        embed_dim=embed_dim,
+        model_name=model.model_name,
+        model_variant=model.model_variant,
+        dataset_name=dataset_name,
+    )
+    ge_set = dge[dataset_name]
+    residual_map = {
+        ge.layer_idx: ge for ge in ge_set.values() if ge.category == category
+    }
+    return AttendedEmbeddings(
+        residual_stream_embeddings=residual_map,
+        foundation_model=model,
+    )
+
+
+def make_attended_embeddings_set(
+    n_models: int = 3,
+    n_shared: int = 15,
+    n_unique_per_model: int = 5,
+    embed_dim: int = 16,
+    n_layers: int = 2,
+    n_heads: int = 2,
+    seed: int = 42,
+) -> Tuple[AttendedEmbeddingsSet, List[str]]:
+    fm, shared_ids = make_foundation_models(
+        n_models=n_models,
+        n_shared=n_shared,
+        n_unique_per_model=n_unique_per_model,
+        embed_dim=embed_dim,
+        n_layers=n_layers,
+        n_heads=n_heads,
+        seed=seed,
+    )
+    models_with_dge: List[FoundationModel] = []
+    for model in fm.models:
+        gene_ids = model.gene_annotations[ONTOLOGIES.ENSEMBL_GENE].tolist()
+        dge = _make_layer_grid_dge(
+            n_layers=model.n_layers,
+            n_categories=2,
+            gene_ids=gene_ids,
+            embed_dim=model.embed_dim,
+            model_name=model.model_name,
+            model_variant=model.model_variant,
+            dataset_name="ds1",
+        )
+        models_with_dge.append(_clone_fm_with_dge(model, dge))
+    fm_with_dge = FoundationModels(models=models_with_dge)
+    attended_set = AttendedEmbeddingsSet.from_expression(
+        fm_with_dge,
+        dataset_name="ds1",
+        category="cluster_0",
+        verbose=False,
+    )
+    return attended_set, shared_ids

--- a/src/tests/foundation_model_factories.py
+++ b/src/tests/foundation_model_factories.py
@@ -8,8 +8,8 @@ from napistu.ontologies.constants import ONTOLOGIES
 
 from napistu_torch.load.constants import FM_DEFS
 from napistu_torch.load.foundation_models import (
-    AttendedEmbeddingsSet,
     AttentionLayer,
+    AttentionPatternsInputs,
     DatasetGeneEmbeddings,
     FoundationModel,
     FoundationModels,
@@ -398,7 +398,7 @@ def make_attended_embeddings_set(
     n_layers: int = 2,
     n_heads: int = 2,
     seed: int = 42,
-) -> Tuple[AttendedEmbeddingsSet, List[str]]:
+) -> Tuple[AttentionPatternsInputs, List[str]]:
     fm, shared_ids = make_foundation_models(
         n_models=n_models,
         n_shared=n_shared,
@@ -422,7 +422,7 @@ def make_attended_embeddings_set(
         )
         models_with_dge.append(_clone_fm_with_dge(model, dge))
     fm_with_dge = FoundationModels(models=models_with_dge)
-    attended_set = AttendedEmbeddingsSet.from_expression(
+    attended_set = AttentionPatternsInputs.from_expression(
         fm_with_dge,
         dataset_name="ds1",
         category="cluster_0",

--- a/src/tests/test_load_foundation_models.py
+++ b/src/tests/test_load_foundation_models.py
@@ -213,7 +213,9 @@ def test_scoping_varying_layer():
 
 def test_validate_dge_passes_full_layer_grid():
     gene_ids = make_gene_ids(6)
-    dge = _make_layer_grid_dge(n_layers=3, n_categories=2, gene_ids=gene_ids)
+    dge = _make_layer_grid_dge(
+        n_layers=3, n_categories=2, gene_ids=gene_ids, model_name="TestModel"
+    )
     fm = _clone_fm_with_dge(
         make_foundation_model(n_genes=6, embed_dim=8, n_layers=3, gene_ids=gene_ids),
         dge,
@@ -248,7 +250,11 @@ def test_validate_dge_fails_all_layer_idx_none():
 def test_validate_dge_fails_missing_layer():
     gene_ids = make_gene_ids(5)
     dge = _make_layer_grid_dge(
-        n_layers=3, n_categories=2, gene_ids=gene_ids, layers_per_emb=[0, 2]
+        n_layers=3,
+        n_categories=2,
+        gene_ids=gene_ids,
+        layers_per_emb=[0, 2],
+        model_name="TestModel",
     )
     fm = _clone_fm_with_dge(
         make_foundation_model(n_genes=5, embed_dim=8, n_layers=3, gene_ids=gene_ids),
@@ -261,7 +267,9 @@ def test_validate_dge_fails_missing_layer():
 
 def test_validate_dge_raises_on_missing_dataset_key():
     gene_ids = make_gene_ids(4)
-    dge = _make_layer_grid_dge(n_layers=2, n_categories=1, gene_ids=gene_ids)
+    dge = _make_layer_grid_dge(
+        n_layers=2, n_categories=1, gene_ids=gene_ids, model_name="TestModel"
+    )
     fm = _clone_fm_with_dge(
         make_foundation_model(n_genes=4, embed_dim=8, n_layers=2, gene_ids=gene_ids),
         dge,
@@ -271,7 +279,7 @@ def test_validate_dge_raises_on_missing_dataset_key():
 
 
 # ---------------------------------------------------------------------------
-# AttendedEmbeddings
+# LayerwiseAttentionInputs
 # ---------------------------------------------------------------------------
 
 

--- a/src/tests/test_load_foundation_models.py
+++ b/src/tests/test_load_foundation_models.py
@@ -1,7 +1,5 @@
 """Tests for foundation model data structures and validation."""
 
-from typing import List, Optional, Tuple
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -9,574 +7,32 @@ from napistu.ontologies.constants import ONTOLOGIES
 
 from napistu_torch.load.constants import FM_DEFS
 from napistu_torch.load.foundation_models import (
-    AttendedEmbeddings,
     AttendedEmbeddingsSet,
-    AttentionLayer,
-    DatasetGeneEmbeddings,
-    FoundationModel,
     FoundationModels,
-    FoundationModelWeights,
     GeneEmbeddings,
     GeneEmbeddingsSet,
-    ModelMetadata,
     _build_embedding_metadata,
     _compute_scoped_keys,
+    _get_model_label,
+    _group_embeddings_by_model_and_category,
+)
+
+from .foundation_model_factories import (
+    SCOPING_TEST_GENES,
+    _clone_fm_with_dge,
+    _make_all_layer_idx_none_dge,
+    _make_gene_annotations,
+    _make_gene_emb,
+    _make_layer_grid_dge,
+    make_foundation_model,
+    make_foundation_model_pair,
+    make_gene_annotations,
+    make_gene_ids,
 )
 
 # ---------------------------------------------------------------------------
-# Low-level factories
+# Module-level helpers
 # ---------------------------------------------------------------------------
-
-
-def make_gene_ids(
-    n: int,
-    prefix: str = "ENSG",
-    start: int = 0,
-) -> List[str]:
-    """Create deterministic gene IDs.
-
-    Parameters
-    ----------
-    n : int
-        Number of gene IDs to create.
-    prefix : str
-        Prefix for each ID (default: "ENSG").
-    start : int
-        Starting index (default: 0).
-
-    Returns
-    -------
-    List[str]
-        e.g., ["ENSG00000", "ENSG00001", ...]
-    """
-    return [f"{prefix}{str(i).zfill(5)}" for i in range(start, start + n)]
-
-
-def make_gene_annotations(
-    gene_ids: List[str],
-    vocab_names: Optional[List[str]] = None,
-    symbols: Optional[List[str]] = None,
-) -> pd.DataFrame:
-    """Create a gene annotations DataFrame.
-
-    Parameters
-    ----------
-    gene_ids : List[str]
-        Ensembl gene IDs.
-    vocab_names : List[str], optional
-        Vocabulary names. If None, uses gene_ids.
-    symbols : List[str], optional
-        Gene symbols. If None, generates SYM_00000, SYM_00001, ...
-
-    Returns
-    -------
-    pd.DataFrame
-        With columns: vocab_name, ensembl_gene, symbol.
-    """
-    if vocab_names is None:
-        vocab_names = list(gene_ids)
-    if symbols is None:
-        symbols = [f"SYM_{str(i).zfill(5)}" for i in range(len(gene_ids))]
-
-    return pd.DataFrame(
-        {
-            "vocab_name": vocab_names,
-            ONTOLOGIES.ENSEMBL_GENE: gene_ids,
-            "symbol": symbols,
-        }
-    )
-
-
-def make_gene_embeddings(
-    n_genes: int = 10,
-    embed_dim: int = 16,
-    gene_ids: Optional[List[str]] = None,
-    vocab_names: Optional[List[str]] = None,
-    model_name: Optional[str] = None,
-    model_variant: Optional[str] = None,
-    dataset_name: Optional[str] = None,
-    category: Optional[str] = None,
-    seed: int = 42,
-) -> GeneEmbeddings:
-    """Create a GeneEmbeddings with deterministic random data.
-
-    Parameters
-    ----------
-    n_genes : int
-        Number of genes (default: 10).
-    embed_dim : int
-        Embedding dimensionality (default: 16).
-    gene_ids : List[str], optional
-        Gene IDs. If None, generates ENSG00000, ENSG00001, ...
-    vocab_names : List[str], optional
-        Vocabulary names. If None, uses gene_ids.
-    model_name : str, optional
-        Source model name.
-    model_variant : str, optional
-        Source model variant.
-    dataset_name : str, optional
-        Source dataset name.
-    category : str, optional
-        Category within dataset.
-    seed : int
-        Random seed for reproducibility (default: 42).
-
-    Returns
-    -------
-    GeneEmbeddings
-    """
-    rng = np.random.default_rng(seed)
-
-    if gene_ids is None:
-        gene_ids = make_gene_ids(n_genes)
-    else:
-        n_genes = len(gene_ids)
-
-    annotations = make_gene_annotations(gene_ids=gene_ids, vocab_names=vocab_names)
-    embedding = rng.standard_normal((n_genes, embed_dim)).astype(np.float32)
-
-    return GeneEmbeddings(
-        embedding=embedding,
-        ordered_gene_ids=gene_ids,
-        gene_annotations=annotations,
-        model_name=model_name,
-        model_variant=model_variant,
-        dataset_name=dataset_name,
-        category=category,
-    )
-
-
-def make_attention_layer(
-    embed_dim: int = 16,
-    layer_idx: int = 0,
-    seed: int = 42,
-) -> AttentionLayer:
-    """Create an AttentionLayer with deterministic random weights.
-
-    Parameters
-    ----------
-    embed_dim : int
-        Model embedding dimension (default: 16).
-    layer_idx : int
-        Layer index (default: 0).
-    seed : int
-        Random seed (default: 42).
-
-    Returns
-    -------
-    AttentionLayer
-    """
-    rng = np.random.default_rng(seed)
-    scale = 1.0 / np.sqrt(embed_dim)
-
-    return AttentionLayer(
-        layer_idx=layer_idx,
-        W_q=rng.standard_normal((embed_dim, embed_dim)).astype(np.float32) * scale,
-        W_k=rng.standard_normal((embed_dim, embed_dim)).astype(np.float32) * scale,
-        W_v=rng.standard_normal((embed_dim, embed_dim)).astype(np.float32) * scale,
-        W_o=rng.standard_normal((embed_dim, embed_dim)).astype(np.float32) * scale,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Mid-level factories
-# ---------------------------------------------------------------------------
-
-
-def make_foundation_model(
-    n_genes: int = 20,
-    embed_dim: int = 16,
-    n_layers: int = 2,
-    n_heads: int = 2,
-    model_name: str = "TestModel",
-    model_variant: Optional[str] = None,
-    gene_ids: Optional[List[str]] = None,
-    vocab_names: Optional[List[str]] = None,
-    extra_vocab: int = 2,
-    seed: int = 42,
-) -> FoundationModel:
-    """Create a complete FoundationModel with deterministic data.
-
-    Generates a model with `n_genes` real genes plus `extra_vocab` special tokens
-    (e.g., <pad>, <cls>). The static gene embedding covers the full vocabulary.
-
-    Parameters
-    ----------
-    n_genes : int
-        Number of real genes (default: 20).
-    embed_dim : int
-        Embedding dimension (default: 16).
-    n_layers : int
-        Number of attention layers (default: 2).
-    n_heads : int
-        Number of attention heads (default: 2).
-    model_name : str
-        Model name (default: "TestModel").
-    model_variant : str, optional
-        Model variant.
-    gene_ids : List[str], optional
-        Gene IDs. If None, generates ENSG00000 through ENSG{n_genes-1}.
-    vocab_names : List[str], optional
-        Vocabulary names for the genes. If None, uses gene_ids.
-    extra_vocab : int
-        Number of extra vocabulary tokens (default: 2).
-    seed : int
-        Random seed (default: 42).
-
-    Returns
-    -------
-    FoundationModel
-    """
-    rng = np.random.default_rng(seed)
-
-    if gene_ids is None:
-        gene_ids = make_gene_ids(n_genes)
-    else:
-        n_genes = len(gene_ids)
-
-    if vocab_names is None:
-        vocab_names = list(gene_ids)
-
-    # Build full vocabulary: genes + special tokens
-    special_tokens = [f"<special_{i}>" for i in range(extra_vocab)]
-    full_vocab = vocab_names + special_tokens
-    n_vocab = len(full_vocab)
-
-    # Gene annotations cover only the real genes
-    annotations = make_gene_annotations(gene_ids=gene_ids, vocab_names=vocab_names)
-
-    # Static embedding covers full vocabulary
-    full_embedding = rng.standard_normal((n_vocab, embed_dim)).astype(np.float32)
-
-    # The GeneEmbeddings for static uses the gene portion only
-    static_ge = GeneEmbeddings(
-        embedding=full_embedding[:n_genes],
-        ordered_gene_ids=gene_ids,
-        gene_annotations=annotations,
-        model_name=model_name,
-        model_variant=model_variant,
-    )
-
-    # Attention layers with different seeds per layer
-    attention_layers = [
-        make_attention_layer(
-            embed_dim=embed_dim,
-            layer_idx=i,
-            seed=seed + i + 1,
-        )
-        for i in range(n_layers)
-    ]
-
-    weights = FoundationModelWeights(
-        static_gene_embeddings=static_ge,
-        attention_layers=attention_layers,
-    )
-
-    metadata = ModelMetadata(
-        model_name=model_name,
-        model_variant=model_variant,
-        n_genes=n_genes,
-        n_vocab=n_vocab,
-        ordered_vocabulary=full_vocab,
-        embed_dim=embed_dim,
-        n_layers=n_layers,
-        n_heads=n_heads,
-    )
-
-    return FoundationModel(
-        weights=weights,
-        gene_annotations=annotations,
-        model_metadata=metadata,
-    )
-
-
-def make_foundation_model_pair(
-    n_shared: int = 15,
-    n_unique_a: int = 5,
-    n_unique_b: int = 5,
-    embed_dim: int = 16,
-    n_layers_a: int = 2,
-    n_layers_b: int = 3,
-    n_heads: int = 2,
-    model_name_a: str = "ModelA",
-    model_name_b: str = "ModelB",
-    use_different_vocab: bool = False,
-    seed: int = 42,
-) -> Tuple[FoundationModel, FoundationModel, List[str]]:
-    """Create two FoundationModels with partially overlapping gene sets.
-
-    This is the key fixture for testing cross-model alignment. The two models
-    share `n_shared` genes and each has unique genes the other doesn't have.
-
-    Parameters
-    ----------
-    n_shared : int
-        Number of shared genes (default: 15).
-    n_unique_a : int
-        Genes only in model A (default: 5).
-    n_unique_b : int
-        Genes only in model B (default: 5).
-    embed_dim : int
-        Embedding dimension (default: 16).
-    n_layers_a : int
-        Layers for model A (default: 2).
-    n_layers_b : int
-        Layers for model B (default: 3).
-    n_heads : int
-        Attention heads (default: 2).
-    model_name_a : str
-        Name for model A (default: "ModelA").
-    model_name_b : str
-        Name for model B (default: "ModelB").
-    use_different_vocab : bool
-        If True, model B uses symbol-based vocab names instead of Ensembl IDs.
-        This tests alignment across different native vocabularies (default: False).
-    seed : int
-        Random seed (default: 42).
-
-    Returns
-    -------
-    model_a : FoundationModel
-    model_b : FoundationModel
-    shared_gene_ids : List[str]
-        The Ensembl gene IDs shared by both models.
-    """
-    shared_ids = make_gene_ids(n_shared, prefix="ENSG", start=0)
-    unique_a_ids = make_gene_ids(n_unique_a, prefix="ENSG", start=n_shared)
-    unique_b_ids = make_gene_ids(n_unique_b, prefix="ENSG", start=n_shared + n_unique_a)
-
-    gene_ids_a = unique_a_ids + shared_ids  # unique first, shared after
-    gene_ids_b = shared_ids + unique_b_ids  # shared first, unique after
-
-    vocab_names_b = None
-    if use_different_vocab:
-        # Model B uses symbols as vocab names
-        symbols_b = [f"SYM_{str(i).zfill(5)}" for i in range(len(gene_ids_b))]
-        vocab_names_b = symbols_b
-
-    model_a = make_foundation_model(
-        gene_ids=gene_ids_a,
-        embed_dim=embed_dim,
-        n_layers=n_layers_a,
-        n_heads=n_heads,
-        model_name=model_name_a,
-        seed=seed,
-    )
-
-    model_b = make_foundation_model(
-        gene_ids=gene_ids_b,
-        vocab_names=vocab_names_b,
-        embed_dim=embed_dim,
-        n_layers=n_layers_b,
-        n_heads=n_heads,
-        model_name=model_name_b,
-        seed=seed + 1000,
-    )
-
-    return model_a, model_b, shared_ids
-
-
-# ---------------------------------------------------------------------------
-# High-level factories
-# ---------------------------------------------------------------------------
-
-
-def make_foundation_models(
-    n_models: int = 3,
-    n_shared: int = 15,
-    n_unique_per_model: int = 5,
-    embed_dim: int = 16,
-    n_layers: int = 2,
-    n_heads: int = 2,
-    seed: int = 42,
-) -> Tuple[FoundationModels, List[str]]:
-    """Create a FoundationModels container with multiple models.
-
-    All models share `n_shared` genes and each has `n_unique_per_model`
-    unique genes.
-
-    Parameters
-    ----------
-    n_models : int
-        Number of models (default: 3, minimum 2).
-    n_shared : int
-        Genes shared across all models (default: 15).
-    n_unique_per_model : int
-        Unique genes per model (default: 5).
-    embed_dim : int
-        Embedding dimension (default: 16).
-    n_layers : int
-        Layers per model (default: 2).
-    n_heads : int
-        Heads per model (default: 2).
-    seed : int
-        Random seed (default: 42).
-
-    Returns
-    -------
-    foundation_models : FoundationModels
-    shared_gene_ids : List[str]
-        Ensembl gene IDs shared by all models.
-    """
-    shared_ids = make_gene_ids(n_shared, prefix="ENSG", start=0)
-
-    models = []
-    for i in range(n_models):
-        unique_start = n_shared + i * n_unique_per_model
-        unique_ids = make_gene_ids(
-            n_unique_per_model, prefix="ENSG", start=unique_start
-        )
-        # Interleave unique and shared to test ordering robustness
-        gene_ids = unique_ids + shared_ids
-
-        model = make_foundation_model(
-            gene_ids=gene_ids,
-            embed_dim=embed_dim,
-            n_layers=n_layers,
-            n_heads=n_heads,
-            model_name=f"TestModel{i}",
-            seed=seed + i * 1000,
-        )
-        models.append(model)
-
-    return FoundationModels(models=models), shared_ids
-
-
-def make_attended_embeddings(
-    n_genes: int = 10,
-    embed_dim: int = 16,
-    n_layers: int = 2,
-    n_heads: int = 2,
-    model_name: str = "TestModel",
-    seed: int = 42,
-) -> AttendedEmbeddings:
-    """Create a single AttendedEmbeddings for unit testing.
-
-    Parameters
-    ----------
-    n_genes : int
-        Number of genes (default: 10).
-    embed_dim : int
-        Embedding dimension (default: 16).
-    n_layers : int
-        Number of layers (default: 2).
-    n_heads : int
-        Number of heads (default: 2).
-    model_name : str
-        Model name (default: "TestModel").
-    seed : int
-        Random seed (default: 42).
-
-    Returns
-    -------
-    AttendedEmbeddings
-    """
-    model = make_foundation_model(
-        n_genes=n_genes,
-        embed_dim=embed_dim,
-        n_layers=n_layers,
-        n_heads=n_heads,
-        model_name=model_name,
-        seed=seed,
-    )
-
-    return AttendedEmbeddings(
-        gene_embeddings=model.weights.static_gene_embeddings,
-        foundation_model=model,
-    )
-
-
-def make_attended_embeddings_set(
-    n_models: int = 3,
-    n_shared: int = 15,
-    n_unique_per_model: int = 5,
-    embed_dim: int = 16,
-    n_layers: int = 2,
-    n_heads: int = 2,
-    seed: int = 42,
-) -> Tuple[AttendedEmbeddingsSet, List[str]]:
-    """Create an AttendedEmbeddingsSet for cross-model testing.
-
-    Parameters
-    ----------
-    n_models : int
-        Number of models (default: 3, minimum 2).
-    n_shared : int
-        Shared genes (default: 15).
-    n_unique_per_model : int
-        Unique genes per model (default: 5).
-    embed_dim : int
-        Embedding dimension (default: 16).
-    n_layers : int
-        Layers per model (default: 2).
-    n_heads : int
-        Heads per model (default: 2).
-    seed : int
-        Random seed (default: 42).
-
-    Returns
-    -------
-    attended_set : AttendedEmbeddingsSet
-    shared_gene_ids : List[str]
-        Gene IDs common to all models.
-    """
-    fm, shared_ids = make_foundation_models(
-        n_models=n_models,
-        n_shared=n_shared,
-        n_unique_per_model=n_unique_per_model,
-        embed_dim=embed_dim,
-        n_layers=n_layers,
-        n_heads=n_heads,
-        seed=seed,
-    )
-
-    attended_set = AttendedEmbeddingsSet.from_static(
-        fm, align_on=ONTOLOGIES.ENSEMBL_GENE
-    )
-
-    return attended_set, shared_ids
-
-
-# utility functions
-
-# Ensembl IDs shared by scoping tests (same genes; source_labels differ by
-# model/dataset/category/layer).
-SCOPING_TEST_GENES = [
-    "ENSG00000000001",
-    "ENSG00000000002",
-    "ENSG00000000003",
-]
-
-
-def _make_gene_annotations(genes):
-    """DataFrame valid for GeneAnnotations (vocab_name + ensembl_gene)."""
-    return pd.DataFrame(
-        {
-            FM_DEFS.VOCAB_NAME: list(genes),
-            ONTOLOGIES.ENSEMBL_GENE: list(genes),
-        }
-    )
-
-
-def _make_gene_emb(
-    genes,
-    embed_dim=4,
-    model_name=None,
-    dataset_name=None,
-    category=None,
-    layer_idx=None,
-):
-    """Minimal GeneEmbeddings for tests."""
-    n = len(genes)
-    return GeneEmbeddings(
-        embedding=np.arange(n * embed_dim, dtype=np.float64).reshape(n, embed_dim),
-        ordered_gene_ids=list(genes),
-        gene_annotations=_make_gene_annotations(genes),
-        model_name=model_name,
-        layer_idx=layer_idx,
-        dataset_name=dataset_name,
-        category=category,
-    )
 
 
 def _scope(embeddings):
@@ -585,217 +41,70 @@ def _scope(embeddings):
     return _compute_scoped_keys(metadata)
 
 
-# tests
+# ---------------------------------------------------------------------------
+# GeneEmbeddings
+# ---------------------------------------------------------------------------
 
 
-def test_gene_embeddings_field_validation():
-    """Test GeneEmbeddings embedding field validation: shape and type."""
-    genes = ["g1", "g2", "g3"]
-    ann = _make_gene_annotations(genes)
-
-    # Valid 2D numpy array
-    valid_embeddings = np.random.randn(3, 32)
-    ge = GeneEmbeddings(
-        embedding=valid_embeddings,
-        ordered_gene_ids=genes,
-        gene_annotations=ann,
-    )
-    assert ge.embedding.shape == (3, 32)
-    assert ge.n_genes == 3
-    assert ge.embed_dim == 32
-
-    # Invalid: 3D array
-    with pytest.raises(ValueError) as exc_info:
-        GeneEmbeddings(
-            embedding=np.random.randn(2, 10, 32),
-            ordered_gene_ids=genes[:2],
-            gene_annotations=_make_gene_annotations(genes[:2]),
-        )
-    assert "2-dimensional" in str(exc_info.value)
-    assert "got shape (2, 10, 32)" in str(exc_info.value)
-
-    # Invalid: 1D array
-    with pytest.raises(ValueError) as exc_info:
-        GeneEmbeddings(
-            embedding=np.random.randn(32),
-            ordered_gene_ids=genes,
-            gene_annotations=ann,
-        )
-    assert "2-dimensional" in str(exc_info.value)
-
-
-def test_gene_embeddings_set_validation():
-    """Test GeneEmbeddingsSet: from_gene_embeddings, unique source_label, empty list."""
-    genes = ["g1", "g2", "g3"]
-    ge1 = _make_gene_emb(genes, embed_dim=8, model_name="ModelA", category="type1")
-    ge2 = _make_gene_emb(genes, embed_dim=8, model_name="ModelA", category="type2")
-
-    # Single embedding: wraps directly
-    ge_set = GeneEmbeddingsSet.from_gene_embeddings(
-        [ge1], align_on=ONTOLOGIES.ENSEMBL_GENE
-    )
-    assert ge_set.n_embeddings == 1
-    assert ge_set.n_common_genes == 3
-    assert ge_set.get("ModelA/type1") is ge1
-
-    # Multiple embeddings with unique source_label: aligns to common genes
-    ge_set2 = GeneEmbeddingsSet.from_gene_embeddings([ge1, ge2])
-    assert ge_set2.n_embeddings == 2
-    assert ge_set2.n_common_genes == 3
-    assert set(ge_set2.keys()) == {"type1", "type2"}
-
-    # Invalid: duplicate source_label
-    ge_dup = _make_gene_emb(genes, embed_dim=8, model_name="ModelA", category="type1")
-    with pytest.raises(ValueError) as exc_info:
-        GeneEmbeddingsSet.from_gene_embeddings([ge1, ge_dup])
-    assert "Duplicate source_label" in str(exc_info.value)
-
-    # Invalid: empty list
-    with pytest.raises(ValueError) as exc_info:
-        GeneEmbeddingsSet.from_gene_embeddings([])
-    assert "requires at least 1 embedding" in str(exc_info.value)
-
-
-def test_dataset_gene_embeddings():
-    """Test DatasetGeneEmbeddings: get, keys, values, items, dict init."""
-    genes = ["g1", "g2", "g3"]
-    ge1a = _make_gene_emb(genes, embed_dim=32, model_name="scGPT", category="type1")
-    ge1b = _make_gene_emb(genes, embed_dim=32, model_name="scGPT", category="type2")
-    set1 = GeneEmbeddingsSet.from_gene_embeddings([ge1a, ge1b])
-
-    ge2a = _make_gene_emb(genes, embed_dim=32, model_name="scGPT", category="a")
-    ge2b = _make_gene_emb(genes, embed_dim=32, model_name="scGPT", category="b")
-    ge2c = _make_gene_emb(genes, embed_dim=32, model_name="scGPT", category="c")
-    set2 = GeneEmbeddingsSet.from_gene_embeddings([ge2a, ge2b, ge2c])
-
-    # Init from dict
-    container = DatasetGeneEmbeddings({"efthymiou": set1, "tabula_sapiens": set2})
-    assert container.get("efthymiou") is set1
-    assert container["efthymiou"] is set1
-    assert container.get("tabula_sapiens") is set2
-    assert "efthymiou" in container
-    assert "missing" not in container
-    assert set(container.keys()) == {"efthymiou", "tabula_sapiens"}
-    assert list(container.values()) == [set1, set2]
-    assert len(list(container.items())) == 2
-    assert "DatasetGeneEmbeddings" in repr(container)
-
-    # KeyError when not found
-    with pytest.raises(KeyError) as exc_info:
-        container.get("nonexistent")
-    assert "nonexistent" in str(exc_info.value)
-    assert "Available datasets" in str(exc_info.value)
-
-    # Invalid: value must be GeneEmbeddingsSet
-    with pytest.raises(ValueError) as exc_info:
-        DatasetGeneEmbeddings(
-            {"bad": ge1a}
-        )  # ge1a is GeneEmbeddings, not GeneEmbeddingsSet
-    assert "must be a GeneEmbeddingsSet" in str(exc_info.value)
-
-    # Invalid: empty dict
-    with pytest.raises(ValueError) as exc_info:
-        DatasetGeneEmbeddings({})
-    assert "requires at least one dataset" in str(exc_info.value)
-
-
-# --- GeneEmbeddings ---
-
-
-def test_gene_embeddings_construction():
-    """GeneEmbeddings construction: valid args and properties."""
-    genes = ["g1", "g2", "g3"]
-    ge = _make_gene_emb(genes, embed_dim=8, model_name="scGPT")
-    assert ge.n_genes == 3
-    assert ge.embed_dim == 8
-    assert ge.ordered_gene_ids == genes
-    assert ge.gene_ids_set == frozenset(genes)
-    assert ge.source_label == "scGPT"
-    assert ge.embedding.shape == (3, 8)
-
-    ge = _make_gene_emb(genes, embed_dim=8, model_name="scGPT", layer_idx=0)
-    assert ge.layer_idx == 0
-    assert ge.source_label == "scGPT/layer_0"
-    assert ge.embedding.shape == (3, 8)
-    assert ge.gene_ids_set == frozenset(genes)
-    assert ge.gene_annotations.shape == (3, 2)
-    assert set(ge.gene_annotations.columns) == {
-        FM_DEFS.VOCAB_NAME,
-        ONTOLOGIES.ENSEMBL_GENE,
-    }
-
-
-def test_gene_embeddings_construction_validation():
-    """GeneEmbeddings rejects bad embedding shape and row/gene count mismatch."""
+def test_gene_embeddings_rejects_3d_array():
     genes = ["g1", "g2"]
-    ann = _make_gene_annotations(genes)
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="2-dimensional"):
         GeneEmbeddings(
             embedding=np.random.randn(2, 3, 4),
             ordered_gene_ids=genes,
-            gene_annotations=ann,
+            gene_annotations=_make_gene_annotations(genes),
         )
-    assert "2-dimensional" in str(e.value)
-    with pytest.raises(ValueError) as e:
+
+
+def test_gene_embeddings_rejects_annotation_mismatch():
+    genes = ["g1", "g2"]
+    with pytest.raises(ValueError, match="gene_annotations has 1 rows"):
         GeneEmbeddings(
             embedding=np.random.randn(2, 4),
             ordered_gene_ids=genes,
             gene_annotations=_make_gene_annotations(["g1"]),
         )
-    assert "gene_annotations has 1 rows" in str(e.value)
-    with pytest.raises(ValueError) as e:
+
+
+def test_gene_embeddings_rejects_duplicate_ids():
+    genes = ["g1", "g2"]
+    with pytest.raises(ValueError, match="unique"):
         GeneEmbeddings(
             embedding=np.random.randn(2, 4),
             ordered_gene_ids=["g1", "g1"],
-            gene_annotations=ann,
+            gene_annotations=_make_gene_annotations(genes),
         )
-    assert "unique" in str(e.value).lower()
-
-    # GeneAnnotations validation: missing required column
-    with pytest.raises(ValueError) as e:
-        GeneEmbeddings(
-            embedding=np.random.randn(2, 4),
-            ordered_gene_ids=genes,
-            gene_annotations=pd.DataFrame({ONTOLOGIES.ENSEMBL_GENE: genes}),
-        )
-    assert "missing required column" in str(e.value).lower()
 
 
-def test_gene_embeddings_align_to_full_match_preserves_order():
-    """align_to with full target list reorders to target order."""
-    ge = _make_gene_emb(["a", "b", "c"], embed_dim=2)
-    aligned = ge.align_to(["c", "a", "b"])
-    assert aligned.ordered_gene_ids == ["c", "a", "b"]
-    assert aligned.n_genes == 3
-    # Row 0 was c (index 2), row 1 was a (0), row 2 was b (1)
-    np.testing.assert_array_equal(aligned.embedding[0], ge.embedding[2])
-    np.testing.assert_array_equal(aligned.embedding[1], ge.embedding[0])
-    np.testing.assert_array_equal(aligned.embedding[2], ge.embedding[1])
+def test_gene_embeddings_source_label_with_layer():
+    ge = _make_gene_emb(["g1", "g2", "g3"], model_name="scGPT", layer_idx=0)
+    assert ge.source_label == "scGPT/layer_0"
+    assert ge.layer_idx == 0
 
 
-def test_gene_embeddings_align_to_subset_and_reorder():
-    """align_to keeps only target genes present in self, in target order."""
-    ge = _make_gene_emb(["a", "b", "c"], embed_dim=2)
-    aligned = ge.align_to(["c", "x", "a"])  # x not in ge
-    assert aligned.ordered_gene_ids == ["c", "a"]
-    assert aligned.n_genes == 2
-    np.testing.assert_array_equal(aligned.embedding[0], ge.embedding[2])
-    np.testing.assert_array_equal(aligned.embedding[1], ge.embedding[0])
+# ---------------------------------------------------------------------------
+# GeneEmbeddingsSet
+# ---------------------------------------------------------------------------
 
 
-def test_gene_embeddings_align_to_no_overlap_raises():
-    """align_to raises when no target_ids are in this embedding."""
-    ge = _make_gene_emb(["a", "b"])
-    with pytest.raises(ValueError) as e:
-        ge.align_to(["x", "y"])
-    assert "No genes in target_ids" in str(e.value)
+def test_gene_embeddings_set_single_wraps_directly():
+    genes = ["g1", "g2", "g3"]
+    ge = _make_gene_emb(genes, model_name="ModelA", category="type1")
+    ge_set = GeneEmbeddingsSet.from_gene_embeddings([ge])
+    assert ge_set.n_embeddings == 1
+    assert ge_set.n_common_genes == 3
 
 
-def test_gene_embeddings_set_unaligned_vocab_output_aligned_and_gene_dim_matches():
-    """From unaligned embeddings with different vocabs, output is aligned and gene dim matches."""
-    # Shared ontology: ensembl_gene. Different native vocabs and order/subset per embedding.
+def test_gene_embeddings_set_rejects_duplicates():
+    genes = ["g1", "g2", "g3"]
+    ge1 = _make_gene_emb(genes, model_name="ModelA", category="type1")
+    ge2 = _make_gene_emb(genes, model_name="ModelA", category="type1")
+    with pytest.raises(ValueError, match="Duplicate source_label"):
+        GeneEmbeddingsSet.from_gene_embeddings([ge1, ge2])
+
+
+def test_gene_embeddings_set_aligns_across_vocabs():
     e1, e2, e3, e4 = "ens_a", "ens_b", "ens_c", "ens_d"
-    # Embedding A: 4 genes, native vocab vA_*
     ann_a = pd.DataFrame(
         {
             FM_DEFS.VOCAB_NAME: ["vA_1", "vA_2", "vA_3", "vA_4"],
@@ -803,12 +112,11 @@ def test_gene_embeddings_set_unaligned_vocab_output_aligned_and_gene_dim_matches
         }
     )
     ge_a = GeneEmbeddings(
-        embedding=np.arange(4 * 2, dtype=np.float64).reshape(4, 2),
+        embedding=np.arange(8, dtype=np.float64).reshape(4, 2),
         ordered_gene_ids=ann_a[FM_DEFS.VOCAB_NAME].tolist(),
         gene_annotations=ann_a,
         model_name="ModelA",
     )
-    # Embedding B: 3 genes, different order (e2, e1, e3), native vocab vB_*
     ann_b = pd.DataFrame(
         {
             FM_DEFS.VOCAB_NAME: ["vB_1", "vB_2", "vB_3"],
@@ -816,221 +124,28 @@ def test_gene_embeddings_set_unaligned_vocab_output_aligned_and_gene_dim_matches
         }
     )
     ge_b = GeneEmbeddings(
-        embedding=np.arange(3 * 3, dtype=np.float64).reshape(3, 3),
+        embedding=np.arange(9, dtype=np.float64).reshape(3, 3),
         ordered_gene_ids=ann_b[FM_DEFS.VOCAB_NAME].tolist(),
         gene_annotations=ann_b,
         model_name="ModelB",
     )
-
-    aligned_set = GeneEmbeddingsSet.from_gene_embeddings(
+    aligned = GeneEmbeddingsSet.from_gene_embeddings(
         [ge_a, ge_b], align_on=ONTOLOGIES.ENSEMBL_GENE
     )
-
-    common = aligned_set.common_gene_ids
-    assert len(common) == 3
-    assert set(common) == {e1, e2, e3}
-    assert aligned_set.n_common_genes == 3
-
-    for key, emb in aligned_set.items():
-        assert emb.gene_ids_in_ontology(ONTOLOGIES.ENSEMBL_GENE) == common
-        assert emb.n_genes == aligned_set.n_common_genes
-
-    summary = aligned_set.summary
-    assert list(summary["n_genes"]) == [3, 3]
-    assert list(summary["key"]) == ["ModelA", "ModelB"]
-
-
-class TestComputeAttentionReordering:
-    """Test that compute_attention with target_ids produces correctly ordered results."""
-
-    def test_target_ids_none_matches_full(self):
-        """Attention with target_ids=None equals full computation."""
-        ae = make_attended_embeddings(n_genes=10, seed=42)
-        full = ae.compute_attention(layer_idx=0, target_ids=None)
-        also_full = ae.compute_attention(
-            layer_idx=0, target_ids=ae.gene_embeddings.ordered_gene_ids
-        )
-        np.testing.assert_allclose(full, also_full, atol=1e-5)
-
-    def test_target_ids_subset_values_match(self):
-        """Subset attention values match corresponding entries in full matrix."""
-        ae = make_attended_embeddings(n_genes=10, seed=42)
-        gene_ids = ae.gene_embeddings.ordered_gene_ids
-
-        full = ae.compute_attention(layer_idx=0, target_ids=None, apply_softmax=False)
-        subset_ids = [gene_ids[2], gene_ids[5], gene_ids[7]]
-        subset = ae.compute_attention(
-            layer_idx=0, target_ids=subset_ids, apply_softmax=False
-        )
-
-        idx = [2, 5, 7]
-        expected = full[np.ix_(idx, idx)]
-        np.testing.assert_allclose(subset, expected, atol=1e-5)
-
-    def test_target_ids_reordering(self):
-        """Reversed target_ids produces transposed-like reordering."""
-        ae = make_attended_embeddings(n_genes=10, seed=42)
-        gene_ids = ae.gene_embeddings.ordered_gene_ids
-
-        forward = ae.compute_attention(layer_idx=0, target_ids=gene_ids[:5])
-        backward = ae.compute_attention(layer_idx=0, target_ids=gene_ids[:5][::-1])
-
-        # backward should be forward with rows and cols reversed
-        np.testing.assert_allclose(backward, forward[::-1, ::-1], atol=1e-5)
-
-
-class TestGetSpecificAttentionsConsistency:
-    """Test that get_specific_attentions returns correct values."""
-
-    def test_values_match_direct_computation(self):
-        """Edge values from get_specific_attentions match direct indexing."""
-        ae = make_attended_embeddings(n_genes=10, n_layers=2, seed=42)
-        gene_ids = ae.gene_embeddings.ordered_gene_ids
-
-        edges = pd.DataFrame(
-            {
-                "from_gene": [gene_ids[0], gene_ids[3]],
-                "to_gene": [gene_ids[1], gene_ids[7]],
-            }
-        )
-
-        result = ae.get_specific_attentions(
-            edges, target_ids=gene_ids, apply_softmax=False
-        )
-
-        for layer_idx in range(ae.n_layers):
-            full_attn = ae.compute_attention(
-                layer_idx=layer_idx, target_ids=gene_ids, apply_softmax=False
-            )
-            layer_rows = result[result["layer"] == layer_idx]
-
-            for _, row in layer_rows.iterrows():
-                i = gene_ids.index(row["from_gene"])
-                j = gene_ids.index(row["to_gene"])
-                np.testing.assert_allclose(row["attention"], full_attn[i, j], atol=1e-5)
-
-
-class TestCrossModelReextractionCompleteness:
-    """Test that cross-model re-extraction produces no NaNs."""
-
-    def test_reextract_union_no_nans(self):
-        """get_top_attentions with reextract_union=True has no NaN values."""
-        attended_set, shared_ids = make_attended_embeddings_set(
-            n_models=2, n_shared=15, n_unique_per_model=5, seed=42
-        )
-
-        result = attended_set.get_top_attentions(
-            k=20,
-            reextract_union=True,
-            compute_ranks=True,
-        )
-
+    assert aligned.n_common_genes == 3
+    assert set(aligned.common_gene_ids) == {e1, e2, e3}
+    for _, emb in aligned.items():
         assert (
-            not result["attention"].isna().any()
-        ), f"Found {result['attention'].isna().sum()} NaN attention values"
-        assert (
-            not result["attention_rank"].isna().any()
-        ), f"Found {result['attention_rank'].isna().sum()} NaN rank values"
-
-    def test_reextract_union_pivot_complete(self):
-        """Pivoted re-extraction has no NaN cells (all model×layer combos present)."""
-        attended_set, shared_ids = make_attended_embeddings_set(
-            n_models=2, n_shared=15, n_unique_per_model=5, seed=42
-        )
-
-        result = attended_set.get_top_attentions(
-            k=20,
-            reextract_union=True,
-        )
-
-        pivot = result.pivot(
-            index=["from_gene", "to_gene"],
-            columns=["model", "layer"],
-            values="attention",
-        )
-
-        n_nans = pivot.isna().sum().sum()
-        assert n_nans == 0, (
-            f"Pivot has {n_nans} NaN cells. "
-            f"Shape: {pivot.shape}, "
-            f"NaN per column:\n{pivot.isna().sum()}"
-        )
-
-    def test_all_edges_use_common_genes_only(self):
-        """Re-extracted edges only reference genes in the common set."""
-        attended_set, shared_ids = make_attended_embeddings_set(
-            n_models=2, n_shared=15, n_unique_per_model=5, seed=42
-        )
-
-        result = attended_set.get_top_attentions(
-            k=20,
-            reextract_union=True,
-        )
-
-        common_set = set(attended_set.common_gene_ids)
-        from_genes = set(result["from_gene"].unique())
-        to_genes = set(result["to_gene"].unique())
-
-        assert from_genes.issubset(common_set), (
-            f"from_gene contains genes not in common set: " f"{from_genes - common_set}"
-        )
-        assert to_genes.issubset(common_set), (
-            f"to_gene contains genes not in common set: " f"{to_genes - common_set}"
+            emb.gene_ids_in_ontology(ONTOLOGIES.ENSEMBL_GENE) == aligned.common_gene_ids
         )
 
 
-class TestConsensusTopAttentionsCompleteness:
-    """Same completeness tests for consensus path."""
-
-    def test_consensus_reextract_no_nans(self):
-        """get_consensus_top_attentions with reextract_union has no NaNs."""
-        attended_set, shared_ids = make_attended_embeddings_set(
-            n_models=2, n_shared=15, n_unique_per_model=5, seed=42
-        )
-
-        result = attended_set.get_consensus_top_attentions(
-            k=20,
-            reextract_union=True,
-        )
-
-        assert not result["attention"].isna().any()
+# ---------------------------------------------------------------------------
+# Scoping
+# ---------------------------------------------------------------------------
 
 
-class TestWithDifferentVocabularies:
-    """Test cross-model operations when models use different native vocabularies."""
-
-    def test_different_vocab_no_nans(self):
-        """Models with different vocab names still produce complete re-extraction."""
-        model_a, model_b, shared_ids = make_foundation_model_pair(
-            n_shared=15,
-            n_unique_a=5,
-            n_unique_b=5,
-            use_different_vocab=True,
-            seed=42,
-        )
-
-        fm = FoundationModels(models=[model_a, model_b])
-        attended_set = AttendedEmbeddingsSet.from_static(fm)
-
-        result = attended_set.get_top_attentions(
-            k=20,
-            reextract_union=True,
-        )
-
-        pivot = result.pivot(
-            index=["from_gene", "to_gene"],
-            columns=["model", "layer"],
-            values="attention",
-        )
-
-        assert (
-            pivot.isna().sum().sum() == 0
-        ), "NaN values found with different vocabulary models"
-
-
-def test_scoping_current_behavior():
-    """Baseline: constant fields fold into label, varying fields go in keys."""
-    # Varying category only
+def test_scoping_varying_category_only():
     scoped, constant = _scope(
         [
             _make_gene_emb(
@@ -1050,7 +165,8 @@ def test_scoping_current_behavior():
     assert set(scoped.values()) == {"adipocyte", "T_cell"}
     assert constant == "scGPT / ds1"
 
-    # Varying model only
+
+def test_scoping_varying_model_only():
     scoped, constant = _scope(
         [
             _make_gene_emb(SCOPING_TEST_GENES, model_name="scGPT"),
@@ -1060,52 +176,8 @@ def test_scoping_current_behavior():
     assert set(scoped.values()) == {"scGPT", "scPRINT"}
     assert constant == ""
 
-    # Two varying fields compose
-    scoped, _ = _scope(
-        [
-            _make_gene_emb(
-                SCOPING_TEST_GENES, model_name="scGPT", category="adipocyte"
-            ),
-            _make_gene_emb(SCOPING_TEST_GENES, model_name="scGPT", category="T_cell"),
-            _make_gene_emb(
-                SCOPING_TEST_GENES, model_name="scPRINT", category="adipocyte"
-            ),
-            _make_gene_emb(SCOPING_TEST_GENES, model_name="scPRINT", category="T_cell"),
-        ]
-    )
-    assert set(scoped.values()) == {
-        "scGPT/adipocyte",
-        "scGPT/T_cell",
-        "scPRINT/adipocyte",
-        "scPRINT/T_cell",
-    }
 
-
-def test_scoping_with_layer_idx():
-    """After adding layer_idx to SCOPING_FIELDS: constant layer folds, varying layer appears in keys."""
-    # Constant layer_idx=0 across all embeddings -> keys unchanged from pre-migration
-    scoped, _ = _scope(
-        [
-            _make_gene_emb(
-                SCOPING_TEST_GENES,
-                model_name="scGPT",
-                dataset_name="ds1",
-                category="adipocyte",
-                layer_idx=0,
-            ),
-            _make_gene_emb(
-                SCOPING_TEST_GENES,
-                model_name="scGPT",
-                dataset_name="ds1",
-                category="T_cell",
-                layer_idx=0,
-            ),
-        ]
-    )
-
-    assert set(scoped.values()) == {"adipocyte", "T_cell"}
-
-    # Varying layer -> layer in keys
+def test_scoping_varying_layer():
     scoped, constant = _scope(
         [
             _make_gene_emb(
@@ -1131,226 +203,262 @@ def test_scoping_with_layer_idx():
             ),
         ]
     )
-
     assert len(set(scoped.values())) == 3
     assert constant == "scGPT / ds1 / adipocyte"
 
 
-def _metadata_dict_from_model(fm: FoundationModel) -> dict:
-    """Rebuild metadata dict for cloning a FoundationModel in tests."""
-    return {
-        FM_DEFS.MODEL_NAME: fm.model_name,
-        FM_DEFS.MODEL_VARIANT: fm.model_variant,
-        FM_DEFS.N_GENES: fm.n_genes,
-        FM_DEFS.N_VOCAB: fm.n_vocab,
-        FM_DEFS.ORDERED_VOCABULARY: fm.ordered_vocabulary,
-        FM_DEFS.EMBED_DIM: fm.embed_dim,
-        FM_DEFS.N_LAYERS: fm.n_layers,
-        FM_DEFS.N_HEADS: fm.n_heads,
-    }
+# ---------------------------------------------------------------------------
+# validate_dataset_gene_embeddings
+# ---------------------------------------------------------------------------
 
 
-def _clone_fm_with_dge(
-    fm: FoundationModel, dge: DatasetGeneEmbeddings
-) -> FoundationModel:
-    return FoundationModel(
-        weights=fm.weights,
-        gene_annotations=fm.gene_annotations,
-        model_metadata=_metadata_dict_from_model(fm),
-        dataset_gene_embeddings=dge,
-    )
-
-
-def _make_layer_grid_dge(
-    *,
-    n_layers: int,
-    n_categories: int,
-    gene_ids: List[str],
-    embed_dim: int = 8,
-    layers_per_emb: Optional[List[int]] = None,
-) -> DatasetGeneEmbeddings:
-    """Expression embeddings: each category repeats one matrix per listed layer."""
-    annotations = make_gene_annotations(gene_ids)
-    rng = np.random.default_rng(42)
-    mats: List[GeneEmbeddings] = []
-    layers_cycle = (
-        layers_per_emb if layers_per_emb is not None else list(range(n_layers))
-    )
-    for ci in range(n_categories):
-        for layer in layers_cycle:
-            emb_mx = rng.standard_normal((len(gene_ids), embed_dim)).astype(np.float32)
-            mats.append(
-                GeneEmbeddings(
-                    embedding=emb_mx,
-                    ordered_gene_ids=list(gene_ids),
-                    gene_annotations=annotations,
-                    model_name="TestModel",
-                    layer_idx=layer,
-                    dataset_name="ds1",
-                    category=f"cluster_{ci}",
-                )
-            )
-    ges = GeneEmbeddingsSet.from_gene_embeddings(mats)
-    return DatasetGeneEmbeddings({"ds1": ges})
-
-
-def _make_all_layer_idx_none_dge(
-    *,
-    gene_ids: List[str],
-    n_embeddings: int = 2,
-    embed_dim: int = 8,
-    dataset_key: str = "ds1",
-) -> DatasetGeneEmbeddings:
-    """Legacy-style expression embeddings with no per-layer residual metadata."""
-    annotations = make_gene_annotations(gene_ids)
-    rng = np.random.default_rng(0)
-    mats: List[GeneEmbeddings] = []
-    for i in range(n_embeddings):
-        emb_mx = rng.standard_normal((len(gene_ids), embed_dim)).astype(np.float32)
-        mats.append(
-            GeneEmbeddings(
-                embedding=emb_mx,
-                ordered_gene_ids=list(gene_ids),
-                gene_annotations=annotations,
-                model_name="TestModel",
-                layer_idx=None,
-                dataset_name=dataset_key,
-                category=f"cluster_{i}",
-            )
-        )
-    ges = GeneEmbeddingsSet.from_gene_embeddings(mats)
-    return DatasetGeneEmbeddings({dataset_key: ges})
-
-
-def test_foundation_model_validate_dataset_gene_embeddings_passes_for_full_layer_grid():
-    """Verification succeeds when every layer index 0..n_layers-1 appears across embeddings."""
+def test_validate_dge_passes_full_layer_grid():
     gene_ids = make_gene_ids(6)
     dge = _make_layer_grid_dge(n_layers=3, n_categories=2, gene_ids=gene_ids)
-    template = make_foundation_model(
-        n_genes=6,
-        embed_dim=8,
-        n_layers=3,
-        gene_ids=gene_ids,
+    fm = _clone_fm_with_dge(
+        make_foundation_model(n_genes=6, embed_dim=8, n_layers=3, gene_ids=gene_ids),
+        dge,
     )
-    fm = _clone_fm_with_dge(template, dge)
     report = fm.validate_dataset_gene_embeddings(verbose=False)
     assert report["ok"]
-    assert len(report["datasets"]) == 1
     assert report["datasets"][0]["distinct_layer_indices"] == (0, 1, 2)
-    assert report["datasets"][0]["spot_check_note"] is not None
 
 
-def test_foundation_model_validate_dataset_gene_embeddings_fails_without_dataset_embeddings():
-    """Verification reports failure when dataset_gene_embeddings was never attached."""
+def test_validate_dge_fails_without_embeddings():
     fm = make_foundation_model()
     report = fm.validate_dataset_gene_embeddings()
     assert not report["ok"]
     assert "dataset_gene_embeddings is None" in report["datasets"][0]["errors"][0]
 
 
-def test_foundation_model_validate_dataset_gene_embeddings_fails_when_all_layer_idx_none():
-    """Legacy exports without layer_idx must fail (layer-wise residual stream required)."""
+def test_validate_dge_fails_all_layer_idx_none():
     gene_ids = make_gene_ids(5)
     dge = _make_all_layer_idx_none_dge(gene_ids=gene_ids, n_embeddings=3)
-    template = make_foundation_model(
-        n_genes=5,
-        embed_dim=8,
-        n_layers=12,
-        gene_ids=gene_ids,
+    fm = _clone_fm_with_dge(
+        make_foundation_model(n_genes=5, embed_dim=8, n_layers=12, gene_ids=gene_ids),
+        dge,
     )
-    fm = _clone_fm_with_dge(template, dge)
     report = fm.validate_dataset_gene_embeddings(verbose=False)
     assert not report["ok"]
-    errs = report["datasets"][0]["errors"]
-    assert any("layer_idx=None" in e and "residual" in e for e in errs)
+    assert any(
+        "layer_idx=None" in e and "residual" in e
+        for e in report["datasets"][0]["errors"]
+    )
 
 
-def test_foundation_model_validate_dataset_gene_embeddings_raise_on_fail():
-    """raise_on_fail surfaces dataset embedding absence."""
-    fm = make_foundation_model()
-    with pytest.raises(ValueError, match="Validation failed"):
-        fm.validate_dataset_gene_embeddings(raise_on_fail=True)
-
-
-def test_foundation_model_validate_dataset_gene_embeddings_missing_layer_indices():
-    """Verification fails when union of layer_idx omits a layer."""
+def test_validate_dge_fails_missing_layer():
     gene_ids = make_gene_ids(5)
     dge = _make_layer_grid_dge(
-        n_layers=3,
-        n_categories=2,
-        gene_ids=gene_ids,
-        layers_per_emb=[0, 2],
+        n_layers=3, n_categories=2, gene_ids=gene_ids, layers_per_emb=[0, 2]
     )
-    template = make_foundation_model(
-        n_genes=5,
-        embed_dim=8,
-        n_layers=3,
-        gene_ids=gene_ids,
+    fm = _clone_fm_with_dge(
+        make_foundation_model(n_genes=5, embed_dim=8, n_layers=3, gene_ids=gene_ids),
+        dge,
     )
-    fm = _clone_fm_with_dge(template, dge)
     report = fm.validate_dataset_gene_embeddings(verbose=False)
     assert not report["ok"]
-    assert any("missing layers [1]" in err for err in report["datasets"][0]["errors"])
+    assert any("missing layers [1]" in e for e in report["datasets"][0]["errors"])
 
 
-def test_foundation_model_validate_dataset_gene_embeddings_detects_zero_variance_embedding():
-    """Verification fails when an embedding matrix is constant (std == 0)."""
-    gene_ids = make_gene_ids(4)
-    annotations = make_gene_annotations(gene_ids)
-    zero_mat = np.zeros((4, 8), dtype=np.float32)
-    mats = [
-        GeneEmbeddings(
-            embedding=zero_mat,
-            ordered_gene_ids=list(gene_ids),
-            gene_annotations=annotations,
-            model_name="TestModel",
-            layer_idx=0,
-            dataset_name="ds1",
-            category="c0",
-        ),
-        GeneEmbeddings(
-            embedding=np.ones((4, 8), dtype=np.float32),
-            ordered_gene_ids=list(gene_ids),
-            gene_annotations=annotations,
-            model_name="TestModel",
-            layer_idx=1,
-            dataset_name="ds1",
-            category="c0",
-        ),
-        GeneEmbeddings(
-            embedding=np.ones((4, 8), dtype=np.float32) * 2,
-            ordered_gene_ids=list(gene_ids),
-            gene_annotations=annotations,
-            model_name="TestModel",
-            layer_idx=2,
-            dataset_name="ds1",
-            category="c0",
-        ),
-    ]
-    ges = GeneEmbeddingsSet.from_gene_embeddings(mats)
-    dge = DatasetGeneEmbeddings({"ds1": ges})
-    template = make_foundation_model(
-        n_genes=4,
-        embed_dim=8,
-        n_layers=3,
-        gene_ids=gene_ids,
-    )
-    fm = _clone_fm_with_dge(template, dge)
-    report = fm.validate_dataset_gene_embeddings(verbose=False)
-    assert not report["ok"]
-    assert any("embedding.std()" in err for err in report["datasets"][0]["errors"])
-
-
-def test_foundation_model_validate_dataset_gene_embeddings_unknown_dataset_key_raises():
-    """validate_dataset_gene_embeddings(dataset_name=...) raises KeyError for missing dataset."""
+def test_validate_dge_raises_on_missing_dataset_key():
     gene_ids = make_gene_ids(4)
     dge = _make_layer_grid_dge(n_layers=2, n_categories=1, gene_ids=gene_ids)
-    template = make_foundation_model(
-        n_genes=4,
-        embed_dim=8,
-        n_layers=2,
-        gene_ids=gene_ids,
+    fm = _clone_fm_with_dge(
+        make_foundation_model(n_genes=4, embed_dim=8, n_layers=2, gene_ids=gene_ids),
+        dge,
     )
-    fm = _clone_fm_with_dge(template, dge)
     with pytest.raises(KeyError):
         fm.validate_dataset_gene_embeddings(dataset_name="missing_dataset")
+
+
+# ---------------------------------------------------------------------------
+# AttendedEmbeddings
+# ---------------------------------------------------------------------------
+
+
+def test_compute_attention_full_equals_explicit_target(attended_embeddings):
+    ae = attended_embeddings
+    full = ae.compute_attention(layer_idx=0)
+    also_full = ae.compute_attention(layer_idx=0, target_ids=ae.ordered_gene_ids)
+    np.testing.assert_allclose(full, also_full, atol=1e-5)
+
+
+def test_compute_attention_subset_matches_full(attended_embeddings):
+    ae = attended_embeddings
+    gene_ids = ae.ordered_gene_ids
+    full = ae.compute_attention(layer_idx=0, apply_softmax=False)
+    subset = ae.compute_attention(
+        layer_idx=0,
+        target_ids=[gene_ids[2], gene_ids[5], gene_ids[7]],
+        apply_softmax=False,
+    )
+    np.testing.assert_allclose(subset, full[np.ix_([2, 5, 7], [2, 5, 7])], atol=1e-5)
+
+
+def test_compute_attention_reversed_target_ids(attended_embeddings):
+    ae = attended_embeddings
+    gene_ids = ae.ordered_gene_ids[:5]
+    forward = ae.compute_attention(layer_idx=0, target_ids=gene_ids)
+    backward = ae.compute_attention(layer_idx=0, target_ids=gene_ids[::-1])
+    np.testing.assert_allclose(backward, forward[::-1, ::-1], atol=1e-5)
+
+
+def test_get_specific_attentions_match_direct(attended_embeddings):
+    ae = attended_embeddings
+    gene_ids = ae.ordered_gene_ids
+    edges = pd.DataFrame(
+        {
+            "from_gene": [gene_ids[0], gene_ids[3]],
+            "to_gene": [gene_ids[1], gene_ids[7]],
+        }
+    )
+    result = ae.get_specific_attentions(edges, target_ids=gene_ids, apply_softmax=False)
+    for layer_idx in range(ae.n_layers):
+        full = ae.compute_attention(
+            layer_idx=layer_idx, target_ids=gene_ids, apply_softmax=False
+        )
+        for _, row in result[result["layer"] == layer_idx].iterrows():
+            i = gene_ids.index(row["from_gene"])
+            j = gene_ids.index(row["to_gene"])
+            np.testing.assert_allclose(row["attention"], full[i, j], atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# AttendedEmbeddingsSet
+# ---------------------------------------------------------------------------
+
+
+def test_reextract_union_no_nans(attended_embeddings_set):
+    result = attended_embeddings_set.get_top_attentions(
+        k=20, reextract_union=True, compute_ranks=True
+    )
+    assert not result["attention"].isna().any()
+    assert not result["attention_rank"].isna().any()
+
+
+def test_reextract_union_pivot_complete(attended_embeddings_set):
+    result = attended_embeddings_set.get_top_attentions(k=20, reextract_union=True)
+    pivot = result.pivot(
+        index=["from_gene", "to_gene"],
+        columns=["model", "layer"],
+        values="attention",
+    )
+    assert pivot.isna().sum().sum() == 0
+
+
+def test_edges_use_common_genes_only(attended_embeddings_set):
+    result = attended_embeddings_set.get_top_attentions(k=20, reextract_union=True)
+    common = set(attended_embeddings_set.common_gene_ids)
+    assert set(result["from_gene"].unique()).issubset(common)
+    assert set(result["to_gene"].unique()).issubset(common)
+
+
+def test_consensus_reextract_no_nans(attended_embeddings_set):
+    result = attended_embeddings_set.get_consensus_top_attentions(
+        k=20, reextract_union=True
+    )
+    assert not result["attention"].isna().any()
+
+
+def test_different_vocab_alignment_no_nans():
+    """Models with different native vocabs align correctly via Ensembl IDs."""
+    model_a, model_b, _ = make_foundation_model_pair(
+        n_shared=15,
+        n_unique_a=5,
+        n_unique_b=5,
+        n_layers_a=2,
+        n_layers_b=2,
+        use_different_vocab=True,
+        seed=42,
+    )
+    models_with_dge = []
+    for m in (model_a, model_b):
+        gene_ids = m.gene_annotations[ONTOLOGIES.ENSEMBL_GENE].tolist()
+        dge = _make_layer_grid_dge(
+            n_layers=m.n_layers,
+            n_categories=1,
+            gene_ids=gene_ids,
+            embed_dim=m.embed_dim,
+            model_name=m.model_name,
+            model_variant=m.model_variant,
+            gene_annotations=m.gene_annotations,
+        )
+        models_with_dge.append(_clone_fm_with_dge(m, dge))
+    fm = FoundationModels(models=models_with_dge)
+    attended_set = AttendedEmbeddingsSet.from_expression(
+        fm,
+        dataset_name="ds1",
+        category="cluster_0",
+        verbose=False,
+    )
+    result = attended_set.get_top_attentions(k=20, reextract_union=True)
+    pivot = result.pivot(
+        index=["from_gene", "to_gene"],
+        columns=["model", "layer"],
+        values="attention",
+    )
+    assert pivot.isna().sum().sum() == 0
+
+
+def test_group_embeddings_by_model_and_category():
+    """Groups correctly and rejects bad inputs."""
+
+    genes = make_gene_ids(5)
+    annotations = make_gene_annotations(genes)
+
+    # Two models, two layers each, one category — happy path
+    embeddings = []
+    for model_name in ("ModelA", "ModelB"):
+        for layer_idx in (0, 1):
+            embeddings.append(
+                GeneEmbeddings(
+                    embedding=np.random.randn(5, 8).astype(np.float32),
+                    ordered_gene_ids=genes,
+                    gene_annotations=annotations,
+                    model_name=model_name,
+                    layer_idx=layer_idx,
+                    dataset_name="ds1",
+                    category="cluster_0",
+                )
+            )
+
+    ge_set = GeneEmbeddingsSet.from_gene_embeddings(embeddings)
+    embedding_to_model = {
+        key: _get_model_label(emb.model_name, emb.model_variant)
+        for key, emb in ge_set.items()
+    }
+
+    groups = _group_embeddings_by_model_and_category(ge_set, embedding_to_model)
+
+    assert set(groups.keys()) == {("ModelA", "cluster_0"), ("ModelB", "cluster_0")}
+    for (model_name, category), layer_dict in groups.items():
+        assert set(layer_dict.keys()) == {0, 1}
+        for layer_idx, ge in layer_dict.items():
+            assert ge.layer_idx == layer_idx
+            assert ge.model_name == model_name
+            assert ge.category == category
+
+    # layer_idx=None is rejected
+    ge_none = GeneEmbeddings(
+        embedding=np.random.randn(5, 8).astype(np.float32),
+        ordered_gene_ids=genes,
+        gene_annotations=annotations,
+        model_name="ModelA",
+        layer_idx=None,
+        dataset_name="ds1",
+        category="cluster_0",
+    )
+    ge_set_none = GeneEmbeddingsSet.from_gene_embeddings([ge_none])
+    with pytest.raises(ValueError, match="layer_idx=None"):
+        _group_embeddings_by_model_and_category(
+            ge_set_none,
+            {list(ge_set_none.keys())[0]: "ModelA"},
+        )
+
+    # Mismatch between embedding model_name and embedding_to_model is caught
+    ge_single = GeneEmbeddingsSet.from_gene_embeddings([embeddings[0]])
+    with pytest.raises(ValueError, match="bug in the embedding_to_model mapping"):
+        _group_embeddings_by_model_and_category(
+            ge_single,
+            {list(ge_single.keys())[0]: "ModelB"},  # deliberate mismatch
+        )

--- a/src/tests/test_load_foundation_models.py
+++ b/src/tests/test_load_foundation_models.py
@@ -19,7 +19,7 @@ from napistu.ontologies.constants import ONTOLOGIES
 
 from napistu_torch.load.constants import FM_DEFS
 from napistu_torch.load.foundation_models import (
-    AttendedEmbeddingsSet,
+    AttentionPatternsInputs,
     FoundationModels,
     GeneEmbeddings,
     GeneEmbeddingsSet,
@@ -331,7 +331,7 @@ def test_get_specific_attentions_match_direct(attended_embeddings):
 
 
 # ---------------------------------------------------------------------------
-# AttendedEmbeddingsSet
+# AttentionPatternsInputs
 # ---------------------------------------------------------------------------
 
 
@@ -392,7 +392,7 @@ def test_different_vocab_alignment_no_nans():
         )
         models_with_dge.append(_clone_fm_with_dge(m, dge))
     fm = FoundationModels(models=models_with_dge)
-    attended_set = AttendedEmbeddingsSet.from_expression(
+    attended_set = AttentionPatternsInputs.from_expression(
         fm,
         dataset_name="ds1",
         category="cluster_0",

--- a/src/tests/test_load_foundation_models.py
+++ b/src/tests/test_load_foundation_models.py
@@ -3,6 +3,18 @@
 import numpy as np
 import pandas as pd
 import pytest
+from foundation_model_factories import (
+    SCOPING_TEST_GENES,
+    _clone_fm_with_dge,
+    _make_all_layer_idx_none_dge,
+    _make_gene_annotations,
+    _make_gene_emb,
+    _make_layer_grid_dge,
+    make_foundation_model,
+    make_foundation_model_pair,
+    make_gene_annotations,
+    make_gene_ids,
+)
 from napistu.ontologies.constants import ONTOLOGIES
 
 from napistu_torch.load.constants import FM_DEFS
@@ -15,19 +27,6 @@ from napistu_torch.load.foundation_models import (
     _compute_scoped_keys,
     _get_model_label,
     _group_embeddings_by_model_and_category,
-)
-
-from .foundation_model_factories import (
-    SCOPING_TEST_GENES,
-    _clone_fm_with_dge,
-    _make_all_layer_idx_none_dge,
-    _make_gene_annotations,
-    _make_gene_emb,
-    _make_layer_grid_dge,
-    make_foundation_model,
-    make_foundation_model_pair,
-    make_gene_annotations,
-    make_gene_ids,
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Residual stream migration

Refactors `napistu_torch` foundation model analysis to use per-layer residual
streams as inputs to attention computation, replacing the previous single static
or expression-contextualized embedding approach. Closes #191 

---

## Summary of changes

- **Removed the static embedding pathway** (`from_static`, single-embedding
  `AttendedEmbeddings`) in favor of requiring per-layer residual streams captured
  by the ETL for all foundation model analysis.

- **Renamed `AttendedEmbeddings` → `LayerwiseAttentionInputs`**, which now holds a
  `Dict[int, GeneEmbeddings]` (one residual stream per layer) instead of a single
  embedding matrix, paired with its `FoundationModel` for attention weight access.
  - `compute_attention(layer_idx)` now dispatches to
    `residual_stream_embeddings[layer_idx].embedding` rather than a fixed single
    matrix, making attention computation mechanistically correct — layer L's weights
    operate on the residual stream *entering* layer L.
  - `__init__` validates that the provided layer indices exactly match
    `range(foundation_model.n_layers)`.

- **Renamed `AttendedEmbeddingsSet` → `AttentionPatternsInputs`**, which now holds
  one `LayerwiseAttentionInputs` per model × category rather than one per model.
  - `from_expression` collects all per-layer `GeneEmbeddings` for a category via
    the new `_get_category_layer_embeddings` helper, which validates complete layer
    coverage per model before returning.
  - `__init__` groups the flat `GeneEmbeddingsSet` into per-(model, category) dicts
    via the new `_group_embeddings_by_model_and_category` helper, which validates
    that scoped key model labels match embedding metadata — catching any mismatch
    between the alignment step and the grouping step.

- **`GeneEmbeddingsSet` is unchanged in design** but now carries
  `n_models × n_layers × n_categories` embeddings when used inside
  `AttentionPatternsInputs`, serving as the source of truth for the common gene
  vocabulary across all models and layers.

- **The `gene_embedding_correlations` comparison** in `compare()` now computes
  Spearman correlations across all `(model, layer, category)` residual stream pairs
  rather than just across models, expanding its interpretive scope from cross-model
  to cross-model × cross-layer.

- **Added two private utility functions** to replace ad-hoc inline logic:
  - `_get_category_layer_embeddings` — extracts and validates per-layer embeddings
    for one category from a `GeneEmbeddingsSet`.
  - `_group_embeddings_by_model_and_category` — groups a flat `GeneEmbeddingsSet`
    into `Dict[Tuple[str, str], Dict[int, GeneEmbeddings]]`, keyed by
    `(model_full_name, category)`.

- **The notebook's `get_all_categories`** was updated to extract categories from
  `ge.category` attributes rather than `GeneEmbeddingsSet` scoped keys, which no
  longer map 1:1 to raw category names after the addition of layer to the scoping
  fields.

- **Test suite restructured** into flat test functions using shared pytest fixtures
  (`foundation_model`, `foundation_models_with_dge`, `attended_embeddings`,
  `attended_embeddings_set`) with factories extracted into a standalone
  `foundation_model_factories.py` module, separating test infrastructure from test
  assertions.